### PR TITLE
Event scheduler, merge after Time handling

### DIFF
--- a/src/core/time/Time.h
+++ b/src/core/time/Time.h
@@ -1,5 +1,5 @@
-#ifndef TIME_H
-#define TIME_H
+#ifndef IRE_CORE_TIME_H
+#define IRE_CORE_TIME_H
 
 #include "core/util/Meta.h"
 
@@ -309,4 +309,4 @@ namespace ire::core {
 
 }
 
-#endif // !TIME_H
+#endif // !IRE_CORE_TIME_H

--- a/src/core/time/TimedCallbackScheduler.cpp
+++ b/src/core/time/TimedCallbackScheduler.cpp
@@ -74,14 +74,14 @@ namespace ire::core {
     {
         while(!m_callbackQueue.isEmpty())
         {
-            auto& [handleRef, nextCallbackRef] = m_callbackQueue.top();
-            if (nextCallbackRef.callbackTime() > now)
+            auto& top = m_callbackQueue.top();
+            if (top.value.callbackTime() > now)
             {
                 break;
             }
 
-            TimedCallback nextCallback = std::move(nextCallbackRef);
-            TimedCallbackHandle handle = handleRef;
+            TimedCallback nextCallback = std::move(top.value);
+            TimedCallbackHandle handle = top.handle;
             auto& creator = nextCallback.creator();
             m_callbackQueue.pop();
 

--- a/src/core/time/TimedCallbackScheduler.cpp
+++ b/src/core/time/TimedCallbackScheduler.cpp
@@ -1,0 +1,106 @@
+#include "TimedCallbackScheduler.h"
+
+namespace ire::core {
+
+    TimedCallbackSchedulerCustomer::TimedCallbackSchedulerCustomer(TimedCallbackScheduler& scheduler) :
+        m_scheduler(&scheduler)
+    {
+    }
+
+    TimedCallbackSchedulerCustomer::~TimedCallbackSchedulerCustomer()
+    {
+        cancelAllCallbacks();
+    }
+
+    void TimedCallbackSchedulerCustomer::handleCallback(const util::OnlyCallableBy<TimedCallbackScheduler>& caller, TimedCallbackHandle handle, TimedCallback&& callback)
+    {
+        assert(&*caller == m_scheduler);
+
+        stopTrackingCallback(handle);
+        this->handleCallback(handle, std::move(callback));
+    }
+
+    TimedCallbackHandle TimedCallbackSchedulerCustomer::scheduleCallback(TimePoint time, TimedCallbackPayload&& payload)
+    {
+        auto handle = m_scheduler->scheduleCallback(*this, time, std::move(payload));
+        m_scheduledCallbacks.emplace_back(handle);
+        return handle;
+    }
+
+    void TimedCallbackSchedulerCustomer::cancelCallback(TimedCallbackHandle handle)
+    {
+        stopTrackingCallback(handle);
+        m_scheduler->cancelCallback(*this, handle);
+    }
+
+    void TimedCallbackSchedulerCustomer::cancelAllCallbacks()
+    {
+        for (auto&& handle : m_scheduledCallbacks)
+        {
+            m_scheduler->cancelCallback(*this, handle);
+        }
+
+        m_scheduledCallbacks.clear();
+    }
+
+    void TimedCallbackSchedulerCustomer::stopTrackingCallback(TimedCallbackHandle handle)
+    {
+        auto it = std::find(std::begin(m_scheduledCallbacks), std::end(m_scheduledCallbacks), handle);
+
+        assert(it != std::end(m_scheduledCallbacks));
+
+        std::swap(*it, m_scheduledCallbacks.back());
+        m_scheduledCallbacks.pop_back();
+    }
+
+    TimedCallbackHandle TimedCallbackScheduler::scheduleCallback(
+        const util::OnlyCallableBy<TimedCallbackSchedulerCustomer>& caller,
+        TimePoint time,
+        TimedCallbackPayload&& payload
+    )
+    {
+        return m_callbackQueue.emplace(*caller, time, std::move(payload));
+    }
+
+    void TimedCallbackScheduler::cancelCallback(
+        const util::OnlyCallableBy<TimedCallbackSchedulerCustomer>& caller,
+        TimedCallbackHandle handle
+    )
+    {
+        m_callbackQueue.remove(handle);
+    }
+
+    void TimedCallbackScheduler::update(TimePoint now)
+    {
+        while(!m_callbackQueue.isEmpty())
+        {
+            auto& [handleRef, nextCallbackRef] = m_callbackQueue.top();
+            if (nextCallbackRef.callbackTime() > now)
+            {
+                break;
+            }
+
+            TimedCallback nextCallback = std::move(nextCallbackRef);
+            TimedCallbackHandle handle = handleRef;
+            auto& creator = nextCallback.creator();
+            m_callbackQueue.pop();
+
+            creator.handleCallback(
+                *this,
+                handle,
+                std::move(nextCallback)
+            );
+        }
+    }
+
+    TimedCallbackScheduler::~TimedCallbackScheduler()
+    {
+        // The callback scheduler must outlive all of its customers,
+        // otherwise there will be dangling pointers to the scheduler.
+        // It also doesn't make sense for the scheduler to be destroyed
+        // before any customer is destroyed.
+        // If scheduler didn't outlive some customers there will likely be
+        // some scheduled callbacks left.
+        assert(m_callbackQueue.isEmpty());
+    }
+}

--- a/src/core/time/TimedCallbackScheduler.h
+++ b/src/core/time/TimedCallbackScheduler.h
@@ -1,0 +1,136 @@
+#ifndef IRE_CORE_TIMED_CALLBACK_SCHEDULER_H
+#define IRE_CORE_TIMED_CALLBACK_SCHEDULER_H
+
+#include "Time.h"
+
+#include "core/util/Meta.h"
+#include "core/util/UpdatablePriorityQueue.h"
+
+#include <cstdint>
+#include <vector>
+#include <utility>
+#include <functional>
+
+namespace ire::core {
+
+    struct TimedCallbackScheduler;
+    struct TimedCallbackSchedulerCustomer;
+
+    struct TimedCallbackPayload
+    {
+        std::uint64_t data;
+    };
+
+    struct TimedCallback
+    {
+        TimedCallback(
+            TimedCallbackSchedulerCustomer& creator,
+            TimePoint callbackTime,
+            TimedCallbackPayload&& payload
+        ) :
+            m_creator(&creator),
+            m_callbackTime(callbackTime),
+            m_payload(std::move(payload))
+        {
+        }
+
+        [[nodiscard]] friend bool operator<(const TimedCallback& lhs, const TimedCallback& rhs) noexcept
+        {
+            return lhs.m_callbackTime < rhs.m_callbackTime;
+        }
+
+        [[nodiscard]] const TimedCallbackSchedulerCustomer& creator() const
+        {
+            return *m_creator;
+        }
+
+        [[nodiscard]] TimedCallbackSchedulerCustomer& creator()
+        {
+            return *m_creator;
+        }
+
+        [[nodiscard]] TimePoint callbackTime() const
+        {
+            return m_callbackTime;
+        }
+
+        [[nodiscard]] TimedCallbackPayload& payload()
+        {
+            return m_payload;
+        }
+
+        [[nodiscard]] const TimedCallbackPayload& payload() const
+        {
+            return m_payload;
+        }
+
+    private:
+        TimedCallbackSchedulerCustomer* m_creator;
+        TimePoint m_callbackTime;
+        TimedCallbackPayload m_payload;
+    };
+
+    using TimedCallbackSchedulerQueueType = util::UpdatablePriorityQueue<TimedCallback, std::less<>>;
+    using TimedCallbackHandle = typename TimedCallbackSchedulerQueueType::ItemHandle;
+
+    struct TimedCallbackSchedulerCustomer
+    {
+        friend struct TimedCallbackScheduler;
+
+        TimedCallbackSchedulerCustomer(TimedCallbackScheduler& scheduler);
+
+        TimedCallbackSchedulerCustomer(const TimedCallbackSchedulerCustomer&) = delete;
+        TimedCallbackSchedulerCustomer(TimedCallbackSchedulerCustomer&&) = delete;
+
+        TimedCallbackSchedulerCustomer& operator=(const TimedCallbackSchedulerCustomer&) = delete;
+        TimedCallbackSchedulerCustomer& operator=(TimedCallbackSchedulerCustomer&&) = delete;
+
+        ~TimedCallbackSchedulerCustomer();
+
+    protected:
+
+        virtual void handleCallback(TimedCallbackHandle handle, TimedCallback&& callback) = 0;
+
+        TimedCallbackHandle scheduleCallback(TimePoint time, TimedCallbackPayload&& payload);
+
+        void cancelCallback(TimedCallbackHandle handle);
+
+    private:
+
+        TimedCallbackScheduler* m_scheduler;
+        std::vector<TimedCallbackHandle> m_scheduledCallbacks;
+
+        void handleCallback(const util::OnlyCallableBy<TimedCallbackScheduler>& caller, TimedCallbackHandle handle, TimedCallback&& callback);
+
+        void cancelAllCallbacks();
+
+        void stopTrackingCallback(TimedCallbackHandle handle);
+    };
+    
+    struct TimedCallbackScheduler final
+    {
+        friend struct TimedCallbackSchedulerCustomer;
+
+        ~TimedCallbackScheduler();
+
+        void update(TimePoint now);
+
+    private:
+
+        TimedCallbackHandle scheduleCallback(
+            const util::OnlyCallableBy<TimedCallbackSchedulerCustomer>& caller,
+            TimePoint time,
+            TimedCallbackPayload&& payload
+        );
+
+        void cancelCallback(
+            const util::OnlyCallableBy<TimedCallbackSchedulerCustomer>& caller,
+            TimedCallbackHandle handle
+        );
+
+        TimedCallbackSchedulerQueueType m_callbackQueue;
+    };
+
+}
+
+#endif // !IRE_CORE_TIMED_CALLBACK_SCHEDULER_H

--- a/src/core/util/Meta.h
+++ b/src/core/util/Meta.h
@@ -1,5 +1,5 @@
-#ifndef META_H
-#define META_H
+#ifndef IRE_CORE_UTIL_META_H
+#define IRE_CORE_UTIL_META_H
 
 namespace ire::core::util {
 
@@ -9,7 +9,7 @@ namespace ire::core::util {
     template <typename AllowedCallerT>
     struct OnlyCallableBy
     {
-        friend struct AllowedCallerT;
+        friend AllowedCallerT;
 
         OnlyCallableBy(const OnlyCallableBy&) = delete;
         OnlyCallableBy(OnlyCallableBy&&) = delete;
@@ -28,4 +28,4 @@ namespace ire::core::util {
 
 }
 
-#endif // !META_H
+#endif // !IRE_CORE_UTIL_META_H

--- a/src/core/util/Meta.h
+++ b/src/core/util/Meta.h
@@ -6,6 +6,26 @@ namespace ire::core::util {
     template <typename T>
     constexpr bool AlwaysFalseV = false;
 
+    template <typename AllowedCallerT>
+    struct OnlyCallableBy
+    {
+        friend struct AllowedCallerT;
+
+        OnlyCallableBy(const OnlyCallableBy&) = delete;
+        OnlyCallableBy(OnlyCallableBy&&) = delete;
+
+        OnlyCallableBy& operator=(const OnlyCallableBy&) = delete;
+        OnlyCallableBy& operator=(OnlyCallableBy&&) = delete;
+
+        AllowedCallerT& operator*() const { return m_caller; }
+        AllowedCallerT* operator->() const { return &m_caller; }
+
+    private:
+        OnlyCallableBy(AllowedCallerT& caller) : m_caller(caller) { }
+
+        AllowedCallerT& m_caller;
+    };
+
 }
 
 #endif // !META_H

--- a/tests/core/time/TimedCallbackSchedulerTests.cpp
+++ b/tests/core/time/TimedCallbackSchedulerTests.cpp
@@ -1,0 +1,97 @@
+#include <catch2/catch.hpp>
+
+#include "core/time/TimedCallbackScheduler.h"
+
+#include <vector>
+#include <cstdint>
+
+TEST_CASE("General testing of TimedCallbackScheduler", "[timed_callback_scheduler]")
+{
+    using namespace ire::core;
+
+    struct MockupCustomer : TimedCallbackSchedulerCustomer
+    {
+        MockupCustomer(TimedCallbackScheduler& scheduler) :
+            TimedCallbackSchedulerCustomer(scheduler)
+        {
+        }
+
+        void handleCallback(TimedCallbackHandle handle, TimedCallback&& callback) override
+        {
+            const auto i = callback.payload().data;
+
+            if (i >= 4320 && i < 4330)
+            {
+                scheduleCallback(callback.callbackTime() + TimeDuration::seconds(1), { i + 1 });
+            }
+
+            handledCallbacks.emplace_back(handle, std::move(callback));
+        }
+
+        void scheduleInitialCallback(TimePoint now, std::uint64_t payload)
+        {
+            scheduleCallback(now + TimeDuration::seconds(1), { payload });
+        }
+
+        std::vector<std::pair<TimedCallbackHandle, TimedCallback>> handledCallbacks;
+    };
+
+    TimedCallbackScheduler scheduler;
+
+    MockupCustomer customer(scheduler);
+
+    TimePoint startTime = TimePoint::now();
+
+    customer.scheduleInitialCallback(startTime, 123);
+
+    REQUIRE(customer.handledCallbacks.empty());
+
+    scheduler.update(startTime);
+
+    REQUIRE(customer.handledCallbacks.empty());
+
+    scheduler.update(startTime + TimeDuration::milliseconds(2));
+
+    REQUIRE(customer.handledCallbacks.empty());
+
+    scheduler.update(startTime + TimeDuration::seconds(2));
+
+    REQUIRE(customer.handledCallbacks.size() == 1);
+    REQUIRE(customer.handledCallbacks[0].second.payload().data == 123);
+    return;
+
+    scheduler.update(startTime + TimeDuration::seconds(4));
+
+    REQUIRE(customer.handledCallbacks.size() == 1);
+
+    customer.scheduleInitialCallback(startTime + TimeDuration::seconds(20), 4320);
+
+    scheduler.update(startTime);
+
+    REQUIRE(customer.handledCallbacks.size() == 1);
+
+    scheduler.update(startTime + TimeDuration::seconds(19));
+
+    REQUIRE(customer.handledCallbacks.size() == 1);
+
+    scheduler.update(startTime + TimeDuration::seconds(20));
+
+    REQUIRE(customer.handledCallbacks.size() == 2);
+    REQUIRE(customer.handledCallbacks[1].second.payload().data == 4320);
+
+    scheduler.update(startTime + TimeDuration::seconds(27));
+
+    REQUIRE(customer.handledCallbacks.size() == 9);
+    REQUIRE(customer.handledCallbacks[2].second.payload().data == 4321);
+    REQUIRE(customer.handledCallbacks[3].second.payload().data == 4322);
+    REQUIRE(customer.handledCallbacks[4].second.payload().data == 4323);
+    REQUIRE(customer.handledCallbacks[5].second.payload().data == 4324);
+    REQUIRE(customer.handledCallbacks[6].second.payload().data == 4325);
+    REQUIRE(customer.handledCallbacks[7].second.payload().data == 4326);
+    REQUIRE(customer.handledCallbacks[8].second.payload().data == 4327);
+
+    scheduler.update(startTime + TimeDuration::seconds(100));
+    REQUIRE(customer.handledCallbacks.size() == 11);
+    REQUIRE(customer.handledCallbacks[9].second.payload().data == 4328);
+    REQUIRE(customer.handledCallbacks[10].second.payload().data == 4329);
+}

--- a/tests/core/util/UpdatablePriorityQueueTests.cpp
+++ b/tests/core/util/UpdatablePriorityQueueTests.cpp
@@ -22,15 +22,15 @@ TEST_CASE("General invariants of the priority queue", "[updatable_priority_queue
 
     v.emplace(0);
 
-    REQUIRE(v.top() == 0);
+    REQUIRE(v.top().value == 0);
 
     id = v.emplace(-1);
 
-    REQUIRE(v.top() == -1);
+    REQUIRE(v.top().value == -1);
 
     v.remove(id);
 
-    REQUIRE(v.top() == 0);
+    REQUIRE(v.top().value == 0);
 
     v.pop();
 
@@ -51,7 +51,7 @@ TEST_CASE("General invariants of the priority queue", "[updatable_priority_queue
     for (int i = 0; i < 100; ++i)
     {
         REQUIRE(!v.isEmpty());
-        REQUIRE(v.top() == i);
+        REQUIRE(v.top().value == i);
         v.pop();
     }
 


### PR DESCRIPTION
This finishes #6. There were changes made to the original spec during the implementation process, most notably:
- event -> callback
- event emitters and handlers are merged to one base class, otherwise it's not hard to ensure consistency and there is no use cases for such separation now
- event handlers can cancel scheduled events
- the scheduler is fixed for an instance of an event handler and must outlive the handler (the scheduler must not have any pending events at its point of destruction)