### PR TITLE
Resource manager.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 notifications:
   email: false
+
 language: cpp
+
 branches:
   only:
-  - master
+    - master
+
 addons:
   apt:
     packages:
@@ -16,25 +19,25 @@ addons:
     - libvorbis-dev
     - libflac-dev
     - libxcursor-dev
-  homebrew:
-    packages:
-     - cmake
     update: true
+
 matrix:
   include:
+    - name: "Ubuntu Focal 20.04 GCC"
+      os: linux
+      dist: focal
+      compiler: gcc
 
-  - name: "Ubuntu Bionic 18.04 GCC"
-    os: linux
-    dist: bionic
-    compiler: gcc
+    - name: "Ubuntu Focal 20.04 Clang"
+      os: linux
+      dist: focal
+      compiler: clang
 
-  - name: "Ubuntu Bionic 18.04 Clang"
-    os: linux
-    dist: bionic
-    compiler: clang
+    - name: "Windows"
+      os: windows
 
-  - name: "Windows"
-    os: windows
+before_install:
+  - eval "${MATRIX_EVAL}"
 
 install:
 - git clone https://github.com/SFML/SFML.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SFML_STATIC_LIBRARIES FALSE CACHE BOOL "Choose whether SFML is linked static
 set(IDLEROMANEMPIRE_STATIC_STD_LIBS FALSE CACHE BOOL "Use statically linked standard/runtime libraries? This option must match the one used for SFML.")
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED 17)
 
 find_package(SFML 2.5 COMPONENTS graphics audio window system REQUIRED)
 
@@ -40,6 +41,9 @@ endif()
 if (BUILD_TESTS)
     add_subdirectory(tests)
 endif()
+
+find_package(Threads REQUIRED)
+target_link_libraries(IdleRomanEmpire Threads::Threads)
 
 target_link_libraries(IdleRomanEmpire IRECore)
 target_link_libraries(IdleRomanEmpire sfml-graphics sfml-audio sfml-window sfml-system)

--- a/src/core/resource/Resource.h
+++ b/src/core/resource/Resource.h
@@ -1,0 +1,75 @@
+#ifndef IRE_RESOURCE_H
+#define IRE_RESOURCE_H
+
+#include "detail/ResourceContainer.h"
+
+#include "ResourcePath.h"
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+namespace ire::core {
+
+    struct ResourceManager;
+
+    // This is a non-owning pointer to a resource container
+    // that provides a resource of type T.
+    // It can only be initialized with a valid resource
+    // pointer from ResourceManager, otherwise
+    // it can only be reset to nullptr.
+    // It defers the dereference to the underlying
+    // resource container.
+    template <typename T>
+    struct ResourcePtr
+    {
+        friend struct ResourceManager;
+
+        ResourcePtr() :
+            m_resource(nullptr)
+        {
+        }
+
+        ResourcePtr(std::nullptr_t) :
+            m_resource(nullptr)
+        {
+        }
+
+        ResourcePtr(const ResourcePtr&) = default;
+        ResourcePtr(ResourcePtr&&) = default;
+
+        ResourcePtr& operator=(const ResourcePtr&) = default;
+        ResourcePtr& operator=(ResourcePtr&&) = default;
+
+        ResourcePtr& operator=(std::nullptr_t)
+        {
+            m_resource = nullptr;
+        }
+
+        [[nodiscard]] const T& operator*() const
+        {
+            return **m_resource;
+        }
+
+        [[nodiscard]] const T* operator->() const
+        {
+            return &**m_resource;
+        }
+
+        [[nodiscard]] operator bool() const
+        {
+            return m_resource != nullptr;
+        }
+
+    private:
+        const detail::SpecificResource<T>* m_resource;
+
+        ResourcePtr(const detail::SpecificResource<T>* resource) :
+            m_resource(resource)
+        {
+        }
+    };
+
+}
+
+#endif // !IRE_RESOURCE_H

--- a/src/core/resource/ResourceLoader.h
+++ b/src/core/resource/ResourceLoader.h
@@ -1,0 +1,33 @@
+#ifndef IRE_RESOURCE_LOADER_H
+#define IRE_RESOURCE_LOADER_H
+
+namespace ire::core::resource_loaders {
+
+    // Users can define their own resource loaders by
+    // specializing this template inside the
+    // ire::core::resource_loaders namespace.
+    // It is up to the user to ensure there are no
+    // conflicting definitions for the same type
+    // of a resource.
+    //
+    // A resource loader must provide two typedefs:
+    //  - ResourceType = T
+    //  - ResourceStorageType - the type used for storage
+    //                          in the resource container.
+    //
+    // It must provide a static method
+    // ResourceType load(const ResourcePath&) method that
+    // (hopefully) loads a resource at the specified path.
+    // It may throw if the resource couldn't be loaded.
+    // 
+    // If ResourceType != ResourceStorageType it must also provide
+    // a static method
+    // const ResourceType& unpack(const ResourceStorageType&)
+    // that returns a reference to the underlying resource.
+    // It must not be a temporary.
+    template <typename T>
+    struct ResourceLoader;
+
+}
+
+#endif // !IRE_RESOURCE_LOADER_H

--- a/src/core/resource/ResourceManager.h
+++ b/src/core/resource/ResourceManager.h
@@ -1,0 +1,148 @@
+#ifndef IRE_RESOURCE_MANAGER_H
+#define IRE_RESOURCE_MANAGER_H
+
+#include "detail/ResourceContainer.h"
+
+#include "ResourcePath.h"
+#include "Resource.h"
+
+#include <set>
+#include <map>
+#include <typeindex>
+#include <filesystem>
+#include <mutex>
+#include <memory>
+#include <type_traits>
+
+namespace ire::core {
+
+    namespace detail {
+
+        // The resource manager utilizes type erasure for the
+        // polymorphic calls to get() because the resource
+        // type is only known in the ResourceManager::get<T>.
+        // This is safe because SpecificResourceManagers are
+        // indexed by matching std::type_index.
+        struct AnyResourceManager
+        {
+            [[nodiscard]] virtual const void* get(const ResourcePath&) = 0;
+        };
+
+        template <typename T>
+        struct SpecificResourceManager : AnyResourceManager
+        {
+            // For now we assume all resource types to be lazy.
+            // In the future we may make it dependent on some
+            // external, possibly per type, value.
+            static constexpr bool isLazy = true;
+
+            using ResourceType = T;
+            using ResourceContainerType =
+                std::conditional_t<
+                    isLazy,
+                    detail::LazyResource<T>,
+                    detail::EagerResource<T>
+                >;
+
+            [[nodiscard]] const void* get(const ResourcePath& path) override
+            {
+                std::unique_lock lock(m_mutex);
+
+                auto it = m_resources.find(path);
+                if (it == m_resources.end())
+                {
+                    std::unique_ptr<SpecificResource<T>> newResource =
+                        std::make_unique<ResourceContainerType>(path);
+
+                    it = m_resources.emplace_hint(it, std::move(newResource));
+                }
+
+                // This won't load the resource because we're just
+                // returning the pointer to the resource container.
+                // The get() is on the unique_ptr.
+                return it->get();
+            }
+
+        private:
+            struct Comparator
+            {
+                using is_transparent = std::true_type;
+
+                using ValueType = std::unique_ptr<SpecificResource<T>>;
+
+                [[nodiscard]] bool operator()(const ValueType& lhs, const ValueType& rhs) const
+                {
+                    return lhs->path() < rhs->path();
+                }
+
+                [[nodiscard]] bool operator()(const ValueType& lhs, const ResourcePath& rhs) const
+                {
+                    return lhs->path() < rhs;
+                }
+
+                [[nodiscard]] bool operator()(const ResourcePath& lhs, const ValueType& rhs) const
+                {
+                    return lhs < rhs->path();
+                }
+            };
+
+            // Since the resources have immutable paths
+            // and are themselves not movable nor copyable
+            // we can safely store the pointer to their
+            // internal path member.
+            // Also we make sure that the resource containers
+            // are never moved in memory so that the created
+            // pointers are valid for the whole lifetime
+            // of this class.
+            std::set<std::unique_ptr<SpecificResource<T>>, Comparator> m_resources;
+            mutable std::mutex m_mutex;
+        };
+
+    }
+
+    // This class is a resource manager singleton.
+    // It outlives all local (non-static) references
+    // to the resources acquired from it.
+    struct ResourceManager
+    {
+        [[nodiscard]] static ResourceManager& instance()
+        {
+            static ResourceManager s_instance;
+            return s_instance;
+        }
+
+        template <typename T, typename PathT>
+        [[nodiscard]] ResourcePtr<T> get(PathT&& patharg)
+        {
+            const ResourcePath path(std::forward<PathT>(patharg));
+
+            std::unique_lock lock(m_mutex);
+
+            auto idx = std::type_index(typeid(T));
+            auto it = m_specificResourceManagers.find(idx);
+            if (it == m_specificResourceManagers.end())
+            {
+                it = m_specificResourceManagers.emplace_hint(
+                    it,
+                    idx, 
+                    std::make_unique<detail::SpecificResourceManager<T>>()
+                );
+            }
+
+            auto srm = it->second.get();
+            lock.unlock();
+
+            auto resource = static_cast<const detail::SpecificResource<T>*>(srm->get(path));
+            return ResourcePtr<T>(resource);
+        }
+
+    private:
+        std::map<std::type_index, std::unique_ptr<detail::AnyResourceManager>> m_specificResourceManagers;
+        mutable std::mutex m_mutex;
+
+        ResourceManager() = default;
+    };
+
+}
+
+#endif // !IRE_RESOURCE_MANAGER_H

--- a/src/core/resource/ResourcePath.h
+++ b/src/core/resource/ResourcePath.h
@@ -1,0 +1,98 @@
+#ifndef IRE_RESOURCE_PATH_H
+#define IRE_RESOURCE_PATH_H
+
+#include <filesystem>
+#include <exception>
+
+namespace ire::core {
+
+    struct PathEscapesWorkingDirectoryException : std::runtime_error
+    {
+        using BaseType = std::runtime_error;
+
+        PathEscapesWorkingDirectoryException(const std::filesystem::path& path) :
+            BaseType("Path \"" + path.string() + "\" escapes from the working directory.")
+        {
+        }
+    };
+
+    // A resource path is always stored in normal form.
+    // Paths that escape the working directory are
+    // not allowed and an exception will be raised
+    // when such a path is created.
+    struct ResourcePath
+    {
+        ResourcePath() = default;
+
+        template <typename SourceT>
+        explicit ResourcePath(SourceT&& path) :
+            m_path(std::filesystem::path(std::forward<SourceT>(path)).lexically_normal())
+        {
+            if (escapesWorkingDirectory())
+            {
+                throw PathEscapesWorkingDirectoryException(m_path);
+            }
+        }
+
+        ResourcePath(const ResourcePath&) = default;
+        ResourcePath(ResourcePath&&) = default;
+
+        ResourcePath& operator=(const ResourcePath&) = default;
+        ResourcePath& operator=(ResourcePath&&) = default;
+
+        [[nodiscard]] operator const std::filesystem::path& () const
+        {
+            return m_path;
+        }
+
+        [[nodiscard]] const std::filesystem::path& fspath() const
+        {
+            return m_path;
+        }
+
+        [[nodiscard]] friend bool operator==(const ResourcePath& lhs, const ResourcePath& rhs)
+        {
+            return lhs.m_path == rhs.m_path;
+        }
+
+        [[nodiscard]] friend bool operator!=(const ResourcePath& lhs, const ResourcePath& rhs)
+        {
+            return lhs.m_path != rhs.m_path;
+        }
+
+        [[nodiscard]] friend bool operator<(const ResourcePath& lhs, const ResourcePath& rhs)
+        {
+            return lhs.m_path < rhs.m_path;
+        }
+
+        [[nodiscard]] friend bool operator<=(const ResourcePath& lhs, const ResourcePath& rhs)
+        {
+            return lhs.m_path <= rhs.m_path;
+        }
+
+        [[nodiscard]] friend bool operator>(const ResourcePath& lhs, const ResourcePath& rhs)
+        {
+            return lhs.m_path > rhs.m_path;
+        }
+
+        [[nodiscard]] friend bool operator>=(const ResourcePath& lhs, const ResourcePath& rhs)
+        {
+            return lhs.m_path >= rhs.m_path;
+        }
+
+        [[nodiscard]] auto string() const
+        {
+            return m_path.string();
+        }
+
+    private:
+        std::filesystem::path m_path;
+
+        [[nodiscard]] bool escapesWorkingDirectory() const
+        {
+            return !m_path.is_relative() || m_path.string().find("..") == 0;
+        }
+    };
+}
+
+#endif // !IRE_RESOURCE_PATH_H

--- a/src/core/resource/detail/ResourceContainer.h
+++ b/src/core/resource/detail/ResourceContainer.h
@@ -79,7 +79,7 @@ namespace ire::core::detail {
         template <typename PathT>
         EagerResource(PathT&& rpath) :
             BaseType(std::forward<PathT>(rpath)),
-            m_resource(ResourceLoader::load(path()))
+            m_resource(ResourceLoader::load(BaseType::path()))
         {
         }
 
@@ -128,7 +128,7 @@ namespace ire::core::detail {
         [[nodiscard]] const T& get() const override
         {
             std::call_once(m_flag, [&res = m_resource, this]() {
-                res = ResourceLoader::load(path());
+                res = ResourceLoader::load(BaseType::path());
             });
 
             if constexpr (std::is_same_v<T, ResourceStorageType>)

--- a/src/core/resource/detail/ResourceContainer.h
+++ b/src/core/resource/detail/ResourceContainer.h
@@ -1,0 +1,159 @@
+#ifndef IRE_RESOURCE_CONTAINER_H
+#define IRE_RESOURCE_CONTAINER_H
+
+#include "core/resource/ResourceLoader.h"
+#include "core/resource/ResourcePath.h"
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+
+namespace ire::core::detail {
+
+    // This is not an abstract base class but is meant to be used as one.
+    // It only exposes the path accessor.
+    struct AnyResource
+    {
+
+        template <typename PathT>
+        AnyResource(PathT&& path) :
+            m_path(std::forward<PathT>(path))
+        {
+        }
+
+        AnyResource(const AnyResource&) = delete;
+        AnyResource(AnyResource&&) = delete;
+
+        AnyResource& operator=(const AnyResource&) = delete;
+        AnyResource& operator=(AnyResource&&) = delete;
+
+        virtual ~AnyResource() = default;
+
+        [[nodiscard]] const ResourcePath& path() const
+        {
+            return m_path;
+        }
+
+    private:
+        ResourcePath m_path;
+    };
+
+    // This is base class for resource containers.
+    // Every inheriting resource container must
+    // override the protected get() member to
+    // return the underlying resource.
+    template <typename T>
+    struct SpecificResource : AnyResource
+    {
+        using ResourceType = T;
+        using ResourceLoader = resource_loaders::ResourceLoader<T>;
+        using ResourceStorageType = typename ResourceLoader::ResourceStorageType;
+
+        using AnyResource::AnyResource;
+
+        [[nodiscard]] const T& operator*() const
+        {
+            return this->get();
+        }
+
+        [[nodiscard]] const T* operator->() const
+        {
+            return &(this->get());
+        }
+
+    protected:
+        virtual const T& get() const = 0;
+    };
+
+    // This class owns a resource and loads it
+    // on creation. If the stored resource type
+    // differs from the actual resource type
+    // it calls ResourceLoader::unpack() on get().
+    template <typename T>
+    struct EagerResource : SpecificResource<T>
+    {
+        using BaseType = SpecificResource<T>;
+        using typename BaseType::ResourceLoader;
+        using typename BaseType::ResourceStorageType;
+
+        template <typename PathT>
+        EagerResource(PathT&& rpath) :
+            BaseType(std::forward<PathT>(rpath)),
+            m_resource(ResourceLoader::load(path()))
+        {
+        }
+
+    protected:
+        [[nodiscard]] const T& get() const override
+        {
+            if constexpr (std::is_same_v<T, ResourceStorageType>)
+            {
+                return m_resource;
+            }
+            else
+            {
+                static_assert(
+                    std::is_same_v<const T&, decltype(ResourceLoader::unpack(m_resource))>,
+                    "Resource loader must return a reference to the "
+                    "underlying object. It must not be a temporary."
+                );
+
+                return ResourceLoader::unpack(m_resource);
+            }
+        }
+
+    private:
+        ResourceStorageType m_resource;
+    };
+
+    // This class owns a resource and loads it
+    // on first use. If the stored resource type
+    // differs from the actual resource type
+    // it calls ResourceLoader::unpack() on get().
+    template <typename T>
+    struct LazyResource : SpecificResource<T>
+    {
+        using BaseType = SpecificResource<T>;
+        using typename BaseType::ResourceLoader;
+        using typename BaseType::ResourceStorageType;
+
+        template <typename PathT>
+        LazyResource(PathT&& rpath) :
+            BaseType(std::forward<PathT>(rpath)),
+            m_flag{}
+        {
+        }
+
+    protected:
+        [[nodiscard]] const T& get() const override
+        {
+            std::call_once(m_flag, [&res = m_resource, this]() {
+                res = ResourceLoader::load(path());
+            });
+
+            if constexpr (std::is_same_v<T, ResourceStorageType>)
+            {
+                return m_resource;
+            }
+            else
+            {
+                static_assert(
+                    std::is_same_v<const T&, decltype(ResourceLoader::unpack(m_resource))>,
+                    "Resource loader must return a reference to the "
+                    "underlying object. It must not be a temporary."
+                );
+
+                return ResourceLoader::unpack(m_resource);
+            }
+        }
+
+    private:
+        // The members are mutable but they are only mutated
+        // in thread safe manner.
+        mutable ResourceStorageType m_resource;
+        mutable std::once_flag m_flag;
+    };
+
+}
+
+#endif // !IRE_RESOURCE_CONTAINER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ ParseAndAddCatchTests(IRETests)
 
 add_dependencies(IRETests IdleRomanEmpire)
 
+find_package(Threads REQUIRED)
+target_link_libraries(IRETests Threads::Threads)
 target_link_libraries(IRETests sfml-graphics sfml-audio sfml-window sfml-system)
 
 add_custom_target(IRERunTests COMMAND $<TARGET_FILE:IRETests>)

--- a/tests/core/resource/MockedResourceLoaders.h
+++ b/tests/core/resource/MockedResourceLoaders.h
@@ -1,0 +1,40 @@
+#ifndef IRE_MOCKED_RESOURCE_LOADERS_H
+#define IRE_MOCKED_RESOURCE_LOADERS_H
+
+#include "core/resource/ResourceLoader.h"
+#include "core/resource/ResourcePath.h"
+
+namespace ire::core::resource_loaders {
+
+    template <>
+    struct ResourceLoader<std::string>
+    {
+        using ResourceType = std::string;
+        using ResourceStorageType = std::string;
+
+        static inline ResourceStorageType load(const ResourcePath& path)
+        {
+            return "TestString " + path.fspath().filename().string();
+        }
+    };
+
+    template <>
+    struct ResourceLoader<int>
+    {
+        using ResourceType = int;
+        using ResourceStorageType = std::unique_ptr<int>;
+
+        static inline ResourceStorageType load(const ResourcePath& path)
+        {
+            return std::make_unique<int>(std::stoi(path.fspath().string()));
+        }
+
+        static inline const int& unpack(const ResourceStorageType& packed)
+        {
+            return *packed;
+        }
+    };
+
+}
+
+#endif // !IRE_MOCKED_RESOURCE_LOADERS_H

--- a/tests/core/resource/ResourceManagerTests.cpp
+++ b/tests/core/resource/ResourceManagerTests.cpp
@@ -1,0 +1,24 @@
+#include <catch2/catch.hpp>
+
+#include "MockedResourceLoaders.h"
+
+#include "core/resource/Resource.h"
+#include "core/resource/ResourceLoader.h"
+#include "core/resource/ResourceManager.h"
+#include "core/resource/ResourcePath.h"
+
+#include <string>
+#include <filesystem>
+
+TEST_CASE("Test ResourceManager", "[resource]")
+{
+    using namespace ire::core;
+
+    ResourcePtr<std::string> strResource =
+        ResourceManager::instance().get<std::string>("some/path/here.string");
+    REQUIRE(*strResource == "TestString here.string");
+
+    ResourcePtr<int> intResource =
+        ResourceManager::instance().get<int>("123");
+    REQUIRE(*intResource == 123);
+}

--- a/tests/core/resource/ResourceTests.cpp
+++ b/tests/core/resource/ResourceTests.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch.hpp>
+
+#include "MockedResourceLoaders.h"
+
+#include "core/resource/Resource.h"
+#include "core/resource/ResourceLoader.h"
+#include "core/resource/ResourcePath.h"
+
+#include <string>
+#include <filesystem>
+#include <memory>
+
+TEST_CASE("Test EagerResource<T>", "[resource]")
+{
+    using namespace ire::core;
+
+    detail::EagerResource<std::string> rs("path/to/resource.string");
+    REQUIRE(*rs == "TestString resource.string");
+
+    detail::EagerResource<int> ri("123");
+    REQUIRE(*ri == 123);
+}
+
+TEST_CASE("Test LazyResource<T>", "[resource]")
+{
+    using namespace ire::core;
+
+    detail::LazyResource<std::string> rs("path/to/resource.string");
+    REQUIRE(*rs == "TestString resource.string");
+
+    detail::LazyResource<int> ri("123");
+    REQUIRE(*ri == 123);
+}


### PR DESCRIPTION
This PR introduces:

- `ResourcePath` which encapsulates std::filesystem::path and ensures that:
    - it is stored in lexically canonical form
    - it always references a filesystem entity (it doesn't follow links though) that is either the working directory or a child of it. In other words it prevents escaping the program's working directory.
- resource loaders
    - they are specializations of `ire::core::resource_loaders::ResourceLoader<T>` in the same namespace; users can define their own resource loaders. `T` is the type of the resource.
    - `ResourceLoader` contains two typedefs:
        - `ResourceType` - the type of the resource, must be equal to `T`
        - `ResourceStorageType` - the type to use for storage in a resource container
    - `ResourceLoader` contains a `static ResourceType load(path)` method that loads a resource from a given path. The path is relative to the working directory and is guaranteed to be a child of the working directory.
    - if `ResourceStorageType` != `ResourceType` then the `ResourceLoader` must also define `static const ResourceType& unpack(const ResourceStorageType&)` that returns the reference to the underlying object. This mechanism is useful for example when we want to store a `unique_ptr` to the resource for some reason.
- resource containers used by the resource manager internally (they own the loaded resources)
    - `EagerResource<T>` - owns a resource that is loaded (does `ResourceLoader::load`) on creation
    - `LazyResource<T>` - owns a resource that is loaded on first use. This type is thread safe and performs the load only once.
- `ResourcePtr<T>` - a non-owning pointer to a resource container. Returns T* on dereference. For lazy resources it loads them on the first dereference (because it defers to the container and the lazy container handles that.
- `ResourceManager` - a singleton accessible through `ResourceManager::instance()`. It is a singletion because it removes the need of tracking it's lifetime by the resources. It exposes a template method for requesting resources of type `T` and given path/name - `template <typename T, typename PathT> get(PathT path) -> ResourcePtr<T>`