### PR TITLE
[WIP] Events part 2

### DIFF
--- a/src/client/Game/Game.cpp
+++ b/src/client/Game/Game.cpp
@@ -14,12 +14,12 @@ namespace ire::client {
         m_engine.run();
     }
 
-    sf::RenderWindow& Game::getWindow()
+    core::gui::SystemWindow& Game::getWindow()
     {
         return m_window;
     }
 
-    const sf::RenderWindow& Game::getWindow() const
+    const core::gui::SystemWindow& Game::getWindow() const
     {
         return m_window;
     }

--- a/src/client/Game/Game.h
+++ b/src/client/Game/Game.h
@@ -5,6 +5,8 @@
 
 #include "core/gui/SystemWindow.h"
 
+#include "GameWindow.h"
+
 namespace ire::client {
 
     struct Game {
@@ -21,7 +23,8 @@ namespace ire::client {
         Game();
         const unsigned int m_windowWidth{ 1024 };
         const unsigned int m_windowHeight{ 768 };
-        core::gui::SystemWindow m_window;
+
+        GameWindow m_window;
         core::Engine m_engine;
     };
 

--- a/src/client/Game/Game.h
+++ b/src/client/Game/Game.h
@@ -1,8 +1,9 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "../../core/Engine.h"
-#include <SFML/Graphics.hpp>
+#include "core/Engine.h"
+
+#include "core/gui/SystemWindow.h"
 
 namespace ire::client {
 
@@ -11,8 +12,8 @@ namespace ire::client {
 
         void run();
 
-        sf::RenderWindow& getWindow();
-        const sf::RenderWindow& getWindow() const;
+        core::gui::SystemWindow& getWindow();
+        const core::gui::SystemWindow& getWindow() const;
         core::Engine& getEngine();
         const core::Engine& getEngine() const;
 
@@ -20,7 +21,7 @@ namespace ire::client {
         Game();
         const unsigned int m_windowWidth{ 1024 };
         const unsigned int m_windowHeight{ 768 };
-        sf::RenderWindow m_window;
+        core::gui::SystemWindow m_window;
         core::Engine m_engine;
     };
 

--- a/src/client/Game/GameWindow.cpp
+++ b/src/client/Game/GameWindow.cpp
@@ -2,6 +2,8 @@
 
 #include "core/gui/Events.h"
 
+#include <iostream>
+
 namespace ire::client {
 
     void GameWindow::init() 
@@ -14,6 +16,12 @@ namespace ire::client {
         auto btn6Ptr = ire::core::gui::Button::create("test1");
         auto label7Ptr = ire::core::gui::Label::create("test");
         auto editBox8Ptr = ire::core::gui::EditBox::create("test1");
+
+        btn5Ptr->addEventListener<ire::core::gui::MouseClickEvent>(
+            [](ire::core::gui::MouseClickEvent& ev) { std::cout << "Clicked btn5Ptr button\n"; });
+
+        btn6Ptr->addEventListener<ire::core::gui::MouseClickEvent>(
+            [](ire::core::gui::MouseClickEvent& ev) { std::cout << "Clicked btn6Ptr button\n"; });
 
         verticalLayout->add(std::move(btn5Ptr), "Button5");
         verticalLayout->add(std::move(btn6Ptr), "Button6");
@@ -29,6 +37,12 @@ namespace ire::client {
         auto btn2Ptr = ire::core::gui::Button::create("test1");
         auto label3Ptr = ire::core::gui::Label::create("test");
         auto btn4Ptr = ire::core::gui::Button::create("test1");
+
+        btn2Ptr->addEventListener<ire::core::gui::MouseClickEvent>(
+            [](ire::core::gui::MouseClickEvent& ev) { std::cout << "Clicked btn2Ptr button\n"; });
+
+        btn4Ptr->addEventListener<ire::core::gui::MouseClickEvent>(
+            [](ire::core::gui::MouseClickEvent& ev) { std::cout << "Clicked btn4Ptr button\n"; });
 
         horizontalLayout->add(std::move(editBox1Ptr), "EditBox2");
         horizontalLayout->add(std::move(btn2Ptr), "Button2");

--- a/src/client/Game/GameWindow.cpp
+++ b/src/client/Game/GameWindow.cpp
@@ -1,0 +1,49 @@
+#include "GameWindow.h"
+
+namespace ire::client {
+
+    void GameWindow::init() 
+    {
+        verticalLayout = ire::core::gui::VerticalLayout::create({ 500, 400 });
+        //verticalLayout->setPosition({ 100, 100 });
+        verticalLayout->setSpaces(5);
+        verticalLayout->setMargins({ 0, 0, 15, 15 });
+        auto btn5Ptr = ire::core::gui::Button::create("test");
+        auto btn6Ptr = ire::core::gui::Button::create("test1");
+        auto label7Ptr = ire::core::gui::Label::create("test");
+        auto editBox8Ptr = ire::core::gui::EditBox::create("test1");
+
+        verticalLayout->add(std::move(btn5Ptr), "Button5");
+        verticalLayout->add(std::move(btn6Ptr), "Button6");
+        verticalLayout->add(std::move(label7Ptr), "Label1");
+        verticalLayout->add(std::move(editBox8Ptr), "EditBox1");
+
+        verticalLayout->setLayoutStretch({ 1, 3, 6, 2 });
+
+        horizontalLayout = ire::core::gui::HorizontalLayout::create({ 500,400 });
+        horizontalLayout->setSpaces(10);
+        horizontalLayout->setMargins({ 10, 10, 10, 10 });
+        auto editBox1Ptr = ire::core::gui::EditBox::create("test");
+        auto btn2Ptr = ire::core::gui::Button::create("test1");
+        auto label3Ptr = ire::core::gui::Label::create("test");
+        auto btn4Ptr = ire::core::gui::Button::create("test1");
+
+        horizontalLayout->add(std::move(editBox1Ptr), "EditBox2");
+        horizontalLayout->add(std::move(btn2Ptr), "Button2");
+        horizontalLayout->add(std::move(verticalLayout), "VerticalLayout");
+        horizontalLayout->add(std::move(label3Ptr), "Label2");
+        horizontalLayout->add(std::move(btn4Ptr), "Button4");
+
+        horizontalLayout->setLayoutStretch({ 3, 6, 12, 2, 1 });
+
+        panel = ire::core::gui::Panel::create({ 700, 400 }, std::move(horizontalLayout), "HorizontalLayout");
+        //panel->setPosition({200, 200});
+        panel->setPosition({ 200,200 });
+        panel->setOpacity(200);
+        panel->setOutlineColor(sf::Color::Magenta);
+        panel->setOutlineThickness(7);
+
+        setRootPanel(*panel);
+    }
+
+}

--- a/src/client/Game/GameWindow.cpp
+++ b/src/client/Game/GameWindow.cpp
@@ -1,5 +1,7 @@
 #include "GameWindow.h"
 
+#include "core/gui/Events.h"
+
 namespace ire::client {
 
     void GameWindow::init() 

--- a/src/client/Game/GameWindow.h
+++ b/src/client/Game/GameWindow.h
@@ -1,0 +1,37 @@
+#ifndef IRE_GAME_WINDOW_H
+#define IRE_GAME_WINDOW_H
+
+#include "core/gui/SystemWindow.h"
+
+#include "core/gui/widgets/Button.h"
+#include "core/gui/widgets/Label.h"
+#include "core/gui/widgets/EditBox.h"
+#include "core/gui/widgets/Panel.h"
+#include "core/gui/widgets/HorizontalLayout.h"
+#include "core/gui/widgets/VerticalLayout.h"
+
+namespace ire::client {
+
+    struct GameWindow : core::gui::SystemWindow
+    {
+        using BaseType = core::gui::SystemWindow;
+
+        template <typename... Ts>
+        GameWindow(Ts&&... args) :
+            BaseType(std::forward<Ts>(args)...)
+        {
+            init();
+        }
+
+    private:
+        std::unique_ptr<ire::core::gui::Group> group;
+        std::unique_ptr<ire::core::gui::Panel> panel;
+        std::unique_ptr<ire::core::gui::HorizontalLayout> horizontalLayout;
+        std::unique_ptr<ire::core::gui::VerticalLayout> verticalLayout;
+
+        void init();
+    };
+
+}
+
+#endif // !IRE_GAME_WINDOW_H

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -6,44 +6,6 @@ namespace ire::core {
     Engine::Engine(gui::SystemWindow& window)
         : m_window(window)
     {
-        verticalLayout = ire::core::gui::VerticalLayout::create({ 500, 400 });
-        //verticalLayout->setPosition({ 100, 100 });
-        verticalLayout->setSpaces(5);
-        verticalLayout->setMargins({ 0, 0, 15, 15 });
-        auto btn5Ptr = ire::core::gui::Button::create("test");
-        auto btn6Ptr = ire::core::gui::Button::create("test1");
-        auto label7Ptr = ire::core::gui::Label::create("test");
-        auto editBox8Ptr = ire::core::gui::EditBox::create("test1");
-
-        verticalLayout->add(std::move(btn5Ptr), "Button5");
-        verticalLayout->add(std::move(btn6Ptr), "Button6");
-        verticalLayout->add(std::move(label7Ptr), "Label1");
-        verticalLayout->add(std::move(editBox8Ptr), "EditBox1");
-
-        verticalLayout->setLayoutStretch({ 1, 3, 6, 2});
-
-        horizontalLayout = ire::core::gui::HorizontalLayout::create({ 500,400 });
-        horizontalLayout->setSpaces(10);
-        horizontalLayout->setMargins({ 10, 10, 10, 10 });
-        auto editBox1Ptr = ire::core::gui::EditBox::create("test");
-        auto btn2Ptr = ire::core::gui::Button::create("test1");
-        auto label3Ptr = ire::core::gui::Label::create("test");
-        auto btn4Ptr = ire::core::gui::Button::create("test1");
-
-        horizontalLayout->add(std::move(editBox1Ptr), "EditBox2");
-        horizontalLayout->add(std::move(btn2Ptr), "Button2");
-        horizontalLayout->add(std::move(verticalLayout), "VerticalLayout");
-        horizontalLayout->add(std::move(label3Ptr), "Label2");
-        horizontalLayout->add(std::move(btn4Ptr), "Button4");
-
-        horizontalLayout->setLayoutStretch({ 3, 6, 12, 2, 1 });
-
-        panel = ire::core::gui::Panel::create({ 700, 400 }, std::move(horizontalLayout), "HorizontalLayout");
-        //panel->setPosition({200, 200});
-        panel->setPosition({ 200,200 });
-        panel->setOpacity(200);
-        panel->setOutlineColor(sf::Color::Magenta);
-        panel->setOutlineThickness(7);
     }
 
     void Engine::run()
@@ -57,10 +19,7 @@ namespace ire::core {
                 break;
             }
 
-            auto& renderTarget = m_window.getRenderTarget();
-
-            renderTarget.clear();
-            panel->draw(renderTarget);
+            m_window.draw();
             m_window.display();
         }
     }

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -3,7 +3,7 @@
 
 namespace ire::core {
 
-    Engine::Engine(sf::RenderWindow& window)
+    Engine::Engine(gui::SystemWindow& window)
         : m_window(window)
     {
         verticalLayout = ire::core::gui::VerticalLayout::create({ 500, 400 });
@@ -48,16 +48,19 @@ namespace ire::core {
 
     void Engine::run()
     {
-        while (m_window.isOpen()) {
-            sf::Event event;
-            while (m_window.pollEvent(event)) {
-                if (event.type == sf::Event::Closed)
-                    m_window.close();
+        for(;;) 
+        {
+            m_window.processEvents();
+
+            if (!m_window.isOpen())
+            {
+                break;
             }
 
-            m_window.clear();
-            panel->draw(m_window);
-            //horizontalLayout->draw(m_window);
+            auto& renderTarget = m_window.getRenderTarget();
+
+            renderTarget.clear();
+            panel->draw(renderTarget);
             m_window.display();
         }
     }

--- a/src/core/Engine.h
+++ b/src/core/Engine.h
@@ -1,13 +1,8 @@
 #ifndef ENGINE_H
 #define ENGINE_H
 
-#include "gui/widgets/Button.h"
-#include "gui/widgets/Label.h"
-#include "gui/widgets/EditBox.h"
-#include "gui/widgets/Panel.h"
-#include "gui/widgets/HorizontalLayout.h"
-#include "gui/widgets/VerticalLayout.h"
 #include "gui/SystemWindow.h"
+
 #include <memory>
 
 namespace ire::core {
@@ -19,10 +14,6 @@ namespace ire::core {
 
     private:
         gui::SystemWindow& m_window;
-        std::unique_ptr<ire::core::gui::Group> group;
-        std::unique_ptr<ire::core::gui::Panel> panel;
-        std::unique_ptr<ire::core::gui::HorizontalLayout> horizontalLayout;
-        std::unique_ptr<ire::core::gui::VerticalLayout> verticalLayout;
     };
 
 }

--- a/src/core/Engine.h
+++ b/src/core/Engine.h
@@ -1,24 +1,24 @@
 #ifndef ENGINE_H
 #define ENGINE_H
 
-#include <SFML/Graphics.hpp>
 #include "gui/widgets/Button.h"
 #include "gui/widgets/Label.h"
 #include "gui/widgets/EditBox.h"
 #include "gui/widgets/Panel.h"
 #include "gui/widgets/HorizontalLayout.h"
 #include "gui/widgets/VerticalLayout.h"
+#include "gui/SystemWindow.h"
 #include <memory>
 
 namespace ire::core {
 
     struct Engine {
-        Engine(sf::RenderWindow& window);
+        Engine(gui::SystemWindow& window);
 
         void run();
 
     private:
-        sf::RenderWindow& m_window;
+        gui::SystemWindow& m_window;
         std::unique_ptr<ire::core::gui::Group> group;
         std::unique_ptr<ire::core::gui::Panel> panel;
         std::unique_ptr<ire::core::gui::HorizontalLayout> horizontalLayout;

--- a/src/core/gui/EventRoot.h
+++ b/src/core/gui/EventRoot.h
@@ -8,7 +8,7 @@ namespace ire::core::gui {
     struct EventRoot
     {
         virtual void setActiveWidget(Widget& widget) = 0;
-        virtual void resetActiveWidget() = 0;
+        virtual void resetActiveWidget(Widget& widget) = 0;
     };
 
 }

--- a/src/core/gui/EventRoot.h
+++ b/src/core/gui/EventRoot.h
@@ -1,0 +1,16 @@
+#ifndef IRE_EVENT_ROOT_H
+#define IRE_EVENT_ROOT_H
+
+namespace ire::core::gui {
+
+    struct Widget;
+
+    struct EventRoot
+    {
+        virtual void setActiveWidget(Widget& widget) = 0;
+        virtual void resetActiveWidget() = 0;
+    };
+
+}
+
+#endif // !IRE_EVENT_ROOT_H

--- a/src/core/gui/Events.h
+++ b/src/core/gui/Events.h
@@ -267,8 +267,7 @@ namespace ire::core::gui {
 
     struct MouseMovedEvent : RawEvent
     {
-        sf::Vector2f prevPosition;
-        sf::Vector2f currPosition;
+        sf::Vector2f position;
     };
 
     struct MouseEnteredWindowEvent : RawEvent

--- a/src/core/gui/Events.h
+++ b/src/core/gui/Events.h
@@ -194,6 +194,7 @@ namespace ire::core::gui {
 
     struct WindowClosedEvent : Event
     {
+        bool cancel = false;
     };
 
     struct WindowResizedEvent : Event

--- a/src/core/gui/Events.h
+++ b/src/core/gui/Events.h
@@ -192,18 +192,96 @@ namespace ire::core::gui {
         }
     };
 
-    struct MouseDownEvent : Event
+    struct WindowClosedEvent : Event
     {
-        sf::Mouse::Button button;
-        sf::Vector2f coords;
     };
 
-    struct MouseUpEvent : Event
+    struct WindowResizedEvent : Event
     {
-        sf::Mouse::Button button;
-        sf::Vector2f coords;
+        sf::Vector2f newSize;
     };
 
+    struct WindowLostFocus : Event
+    {
+    };
+
+    struct WindowGainedFocus : Event
+    {
+    };
+
+    struct TextEnteredEvent : Event
+    {
+        char32_t character;
+    };
+
+    struct KeyDownEvent : Event
+    {
+        sf::Keyboard::Key key;
+        bool alt;
+        bool control;
+        bool shift;
+        bool system;
+    };
+
+    struct KeyUpEvent : Event
+    {
+        sf::Keyboard::Key key;
+        bool alt;
+        bool control;
+        bool shift;
+        bool system;
+    };
+
+    struct MouseWheelScrolledEvent : Event
+    {
+        sf::Mouse::Wheel wheel;
+        float delta;
+        sf::Vector2f position;
+    };
+
+    struct MouseButtonDownEvent : Event
+    {
+        sf::Mouse::Button button;
+        sf::Vector2f position;
+    };
+
+    struct MouseButtonUpEvent : Event
+    {
+        sf::Mouse::Button button;
+        sf::Vector2f position;
+    };
+
+    struct MouseMovedEvent : Event
+    {
+        sf::Vector2f prevPosition;
+        sf::Vector2f currPosition;
+    };
+
+    struct MouseEnteredWindowEvent : Event
+    {
+    };
+
+    struct MouseLeftWindowEvent : Event
+    {
+    };
+
+    struct TouchBeganEvent : Event
+    {
+        std::uint32_t finger;
+        sf::Vector2f position;
+    };
+
+    struct TouchMovedEvent : Event
+    {
+        std::uint32_t finger;
+        sf::Vector2f position;
+    };
+
+    struct TouchEndedEvent : Event
+    {
+        std::uint32_t finger;
+        sf::Vector2f position;
+    };
 }
 
 #endif // !IRE_EVENTS_H

--- a/src/core/gui/Events.h
+++ b/src/core/gui/Events.h
@@ -177,6 +177,15 @@ namespace ire::core::gui {
             }
         }
 
+        template <typename EventT>
+        void emitEventIfNotHandled(EventT& ev)
+        {
+            if (!ev.handled)
+            {
+                emitEvent<EventT>(ev);
+            }
+        }
+
     private:
         ListenerMapType m_listeners;
 

--- a/src/core/gui/Events.h
+++ b/src/core/gui/Events.h
@@ -3,6 +3,8 @@
 
 #include <SFML/Window/Event.hpp>
 
+#include "core/time/Time.h"
+
 #include <functional>
 #include <type_traits>
 #include <typeindex>
@@ -15,6 +17,7 @@ namespace ire::core::gui {
 
     struct RawEvent
     {
+        TimePoint timestamp{};
         bool handled = false;
     };
 

--- a/src/core/gui/Events.h
+++ b/src/core/gui/Events.h
@@ -13,9 +13,13 @@
 
 namespace ire::core::gui {
 
-    struct Event
+    struct RawEvent
     {
         bool handled = false;
+    };
+
+    struct TranslatedEvent : RawEvent
+    {
     };
 
     struct EventEmitter
@@ -44,7 +48,7 @@ namespace ire::core::gui {
         template <typename EventT, typename FuncT>
         struct EventListener : AnyEventListener, private FuncT
         {
-            static_assert(std::is_base_of_v<Event, EventT>, "EventT must derive from Event");
+            static_assert(std::is_base_of_v<RawEvent, EventT>, "EventT must derive from Event");
             static_assert(
                 std::is_same_v<
                     decltype(std::declval<FuncT>()(std::declval<EventT&>())),
@@ -201,30 +205,30 @@ namespace ire::core::gui {
         }
     };
 
-    struct WindowClosedEvent : Event
+    struct WindowClosedEvent : RawEvent
     {
         bool cancel = false;
     };
 
-    struct WindowResizedEvent : Event
+    struct WindowResizedEvent : RawEvent
     {
         sf::Vector2f newSize;
     };
 
-    struct WindowLostFocus : Event
+    struct WindowLostFocus : RawEvent
     {
     };
 
-    struct WindowGainedFocus : Event
+    struct WindowGainedFocus : RawEvent
     {
     };
 
-    struct TextEnteredEvent : Event
+    struct TextEnteredEvent : RawEvent
     {
         char32_t character;
     };
 
-    struct KeyDownEvent : Event
+    struct KeyDownEvent : RawEvent
     {
         sf::Keyboard::Key key;
         bool alt;
@@ -233,7 +237,7 @@ namespace ire::core::gui {
         bool system;
     };
 
-    struct KeyUpEvent : Event
+    struct KeyUpEvent : RawEvent
     {
         sf::Keyboard::Key key;
         bool alt;
@@ -242,52 +246,52 @@ namespace ire::core::gui {
         bool system;
     };
 
-    struct MouseWheelScrolledEvent : Event
+    struct MouseWheelScrolledEvent : RawEvent
     {
         sf::Mouse::Wheel wheel;
         float delta;
         sf::Vector2f position;
     };
 
-    struct MouseButtonDownEvent : Event
+    struct MouseButtonDownEvent : RawEvent
     {
         sf::Mouse::Button button;
         sf::Vector2f position;
     };
 
-    struct MouseButtonUpEvent : Event
+    struct MouseButtonUpEvent : RawEvent
     {
         sf::Mouse::Button button;
         sf::Vector2f position;
     };
 
-    struct MouseMovedEvent : Event
+    struct MouseMovedEvent : RawEvent
     {
         sf::Vector2f prevPosition;
         sf::Vector2f currPosition;
     };
 
-    struct MouseEnteredWindowEvent : Event
+    struct MouseEnteredWindowEvent : RawEvent
     {
     };
 
-    struct MouseLeftWindowEvent : Event
+    struct MouseLeftWindowEvent : RawEvent
     {
     };
 
-    struct TouchBeganEvent : Event
-    {
-        std::uint32_t finger;
-        sf::Vector2f position;
-    };
-
-    struct TouchMovedEvent : Event
+    struct TouchBeganEvent : RawEvent
     {
         std::uint32_t finger;
         sf::Vector2f position;
     };
 
-    struct TouchEndedEvent : Event
+    struct TouchMovedEvent : RawEvent
+    {
+        std::uint32_t finger;
+        sf::Vector2f position;
+    };
+
+    struct TouchEndedEvent : RawEvent
     {
         std::uint32_t finger;
         sf::Vector2f position;

--- a/src/core/gui/RawEventHandler.cpp
+++ b/src/core/gui/RawEventHandler.cpp
@@ -7,4 +7,13 @@ namespace ire::core::gui {
 		emitEventIfNotHandled<MouseButtonDownEvent>(ev);
 	}
 
+	void RawEventHandler::onEvent(EventRoot& sender, MouseButtonUpEvent& ev)
+	{
+		emitEventIfNotHandled<MouseButtonUpEvent>(ev);
+	}
+
+	void RawEventHandler::onEvent(EventRoot& sender, MouseMovedEvent& ev)
+	{
+		emitEventIfNotHandled<MouseMovedEvent>(ev);
+	}
 }

--- a/src/core/gui/RawEventHandler.cpp
+++ b/src/core/gui/RawEventHandler.cpp
@@ -1,0 +1,10 @@
+#include "RawEventHandler.h"
+
+namespace ire::core::gui {
+
+	void RawEventHandler::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
+	{
+		emitEventIfNotHandled<MouseButtonDownEvent>(ev);
+	}
+
+}

--- a/src/core/gui/RawEventHandler.h
+++ b/src/core/gui/RawEventHandler.h
@@ -9,6 +9,9 @@ namespace ire::core::gui {
     struct RawEventHandler : EventEmitter
     {
         virtual void onEvent(EventRoot& sender, MouseButtonDownEvent& ev);
+        virtual void onEvent(EventRoot& sender, MouseButtonUpEvent& ev);
+        virtual void onEvent(EventRoot& sender, MouseMovedEvent& ev);
+
     };
 
 }

--- a/src/core/gui/RawEventHandler.h
+++ b/src/core/gui/RawEventHandler.h
@@ -1,0 +1,16 @@
+#ifndef IRE_RAW_EVENT_HANDLER_H
+#define IRE_RAW_EVENT_HANDLER_H
+
+#include "EventRoot.h"
+#include "Events.h"
+
+namespace ire::core::gui {
+
+    struct RawEventHandler : EventEmitter
+    {
+        virtual void onEvent(EventRoot& sender, MouseButtonDownEvent& ev);
+    };
+
+}
+
+#endif // !IRE_RAW_EVENT_HANDLER_H

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -31,6 +31,23 @@ namespace ire::core::gui {
         m_window.display();
     }
 
+    void SystemWindow::draw()
+    {
+        auto& renderTarget = getRenderTarget();
+
+        renderTarget.clear();
+
+        if (m_rootPanel)
+        {
+            m_rootPanel->draw(renderTarget);
+        }
+    }
+
+    void SystemWindow::setRootPanel(Panel& panel)
+    {
+        m_rootPanel = &panel;
+    }
+
     void SystemWindow::processSfmlEvent(sf::Event& ev)
     {
         if (ev.type == sf::Event::EventType::Closed)

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -82,13 +82,32 @@ namespace ire::core::gui {
 
         if (isOpen() && m_rootPanel != nullptr)
         {
+            if (m_activeWidget != nullptr)
+            {
+                m_activeWidget->onEvent(*this, translatedEv);
+                if (translatedEv.handled)
+                {
+                    return;
+                }
+            }
+
             if (m_rootPanel->clientBounds().contains(translatedEv.position))
             {
-                m_rootPanel->onEvent(translatedEv);
+                m_rootPanel->onEvent(*this, translatedEv);
             }
 
             emitEventIfNotHandled<MouseButtonDownEvent>(translatedEv);
         }
+    }
+
+    void SystemWindow::setActiveWidget(Widget& widget)
+    {
+        m_activeWidget = &widget;
+    }
+
+    void SystemWindow::resetActiveWidget()
+    {
+        m_activeWidget = nullptr;
     }
 
 }

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -50,14 +50,46 @@ namespace ire::core::gui {
 
     void SystemWindow::processSfmlEvent(sf::Event& ev)
     {
-        if (ev.type == sf::Event::EventType::Closed)
+        switch (ev.type)
         {
-            WindowClosedEvent translatedEv{};
-            emitEvent<WindowClosedEvent>(translatedEv);
+        case sf::Event::EventType::Closed:
+            processSfmlClosedEvent(ev);
+            break;
 
-            if (!translatedEv.cancel)
+        case sf::Event::EventType::MouseButtonPressed:
+            processSfmlMouseButtonPressedEvent(ev);
+        }
+    }
+
+    void SystemWindow::processSfmlClosedEvent(sf::Event& ev)
+    {
+        WindowClosedEvent translatedEv{};
+        emitEvent<WindowClosedEvent>(translatedEv);
+
+        if (!translatedEv.cancel)
+        {
+            close();
+        }
+    }
+
+    void SystemWindow::processSfmlMouseButtonPressedEvent(sf::Event& ev)
+    {
+        MouseButtonDownEvent translatedEv{};
+        translatedEv.button = ev.mouseButton.button;
+        translatedEv.position = sf::Vector2f(
+            static_cast<float>(ev.mouseButton.x), 
+            static_cast<float>(ev.mouseButton.y));
+
+        if (isOpen() && m_rootPanel != nullptr)
+        {
+            if (m_rootPanel->clientBounds().contains(translatedEv.position))
             {
-                close();
+                m_rootPanel->onEvent(translatedEv);
+            }
+
+            if (!translatedEv.handled)
+            {
+                emitEvent<MouseButtonDownEvent>(translatedEv);
             }
         }
     }

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -130,9 +130,25 @@ namespace ire::core::gui {
         m_activeWidget = &widget;
     }
 
-    void SystemWindow::resetActiveWidget()
+    void SystemWindow::resetActiveWidget(Widget& widget)
     {
-        m_activeWidget = nullptr;
+        if (m_activeWidget == &widget)
+        {
+            m_activeWidget = nullptr;
+
+            // We emit mouse moved here so that the thing
+            // that didn't receive the previous event
+            // because it was intercepted.
+            reemitLastMouseMoved();
+        }
+    }
+
+    void SystemWindow::reemitLastMouseMoved()
+    {
+        MouseMovedEvent translatedEv{};
+        translatedEv.timestamp = TimePoint::now();
+        translatedEv.position = sf::Vector2f(m_lastMousePosition);
+        forwardEventWithPosition(translatedEv);
     }
 
 }

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -1,0 +1,48 @@
+#include "SystemWindow.h"
+
+namespace ire::core::gui {
+
+    [[nodiscard]] sf::RenderTarget& SystemWindow::getRenderTarget()
+    {
+        return m_window;
+    }
+
+    [[nodiscard]] bool SystemWindow::isOpen() const
+    {
+        return m_window.isOpen();
+    }
+
+    void SystemWindow::processEvents()
+    {
+        sf::Event ev;
+        while (m_window.pollEvent(ev))
+        {
+            processSfmlEvent(ev);
+        }
+    }
+
+    void SystemWindow::close()
+    {
+        m_window.close();
+    }
+
+    void SystemWindow::display()
+    {
+        m_window.display();
+    }
+
+    void SystemWindow::processSfmlEvent(sf::Event& ev)
+    {
+        if (ev.type == sf::Event::EventType::Closed)
+        {
+            WindowClosedEvent translatedEv{};
+            emitEvent<WindowClosedEvent>(translatedEv);
+
+            if (!translatedEv.cancel)
+            {
+                close();
+            }
+        }
+    }
+
+}

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -87,10 +87,7 @@ namespace ire::core::gui {
                 m_rootPanel->onEvent(translatedEv);
             }
 
-            if (!translatedEv.handled)
-            {
-                emitEvent<MouseButtonDownEvent>(translatedEv);
-            }
+            emitEventIfNotHandled<MouseButtonDownEvent>(translatedEv);
         }
     }
 

--- a/src/core/gui/SystemWindow.cpp
+++ b/src/core/gui/SystemWindow.cpp
@@ -14,10 +14,11 @@ namespace ire::core::gui {
 
     void SystemWindow::processEvents()
     {
+        TimePoint timestamp = TimePoint::now();
         sf::Event ev;
         while (m_window.pollEvent(ev))
         {
-            processSfmlEvent(ev);
+            processSfmlEvent(ev, timestamp);
         }
     }
 
@@ -48,20 +49,20 @@ namespace ire::core::gui {
         m_rootPanel = &panel;
     }
 
-    void SystemWindow::processSfmlEvent(sf::Event& ev)
+    void SystemWindow::processSfmlEvent(sf::Event& ev, TimePoint timestamp)
     {
         switch (ev.type)
         {
         case sf::Event::EventType::Closed:
-            processSfmlClosedEvent(ev);
+            processSfmlClosedEvent(ev, timestamp);
             break;
 
         case sf::Event::EventType::MouseButtonPressed:
-            processSfmlMouseButtonPressedEvent(ev);
+            processSfmlMouseButtonPressedEvent(ev, timestamp);
         }
     }
 
-    void SystemWindow::processSfmlClosedEvent(sf::Event& ev)
+    void SystemWindow::processSfmlClosedEvent(sf::Event& ev, TimePoint timestamp)
     {
         WindowClosedEvent translatedEv{};
         emitEvent<WindowClosedEvent>(translatedEv);
@@ -72,7 +73,7 @@ namespace ire::core::gui {
         }
     }
 
-    void SystemWindow::processSfmlMouseButtonPressedEvent(sf::Event& ev)
+    void SystemWindow::processSfmlMouseButtonPressedEvent(sf::Event& ev, TimePoint timestamp)
     {
         MouseButtonDownEvent translatedEv{};
         translatedEv.button = ev.mouseButton.button;

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -56,11 +56,11 @@ namespace ire::core::gui {
         // of the position of the mouse, etc.
         Widget* m_activeWidget;
 
-        void processSfmlEvent(sf::Event& ev);
+        void processSfmlEvent(sf::Event& ev, TimePoint timestamp);
 
-        void processSfmlClosedEvent(sf::Event& ev);
+        void processSfmlClosedEvent(sf::Event& ev, TimePoint timestamp);
 
-        void processSfmlMouseButtonPressedEvent(sf::Event& ev);
+        void processSfmlMouseButtonPressedEvent(sf::Event& ev, TimePoint timestamp);
     };
 
 }

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -47,7 +47,7 @@ namespace ire::core::gui {
         void setRootPanel(Panel& panel);
 
         void setActiveWidget(Widget& widget) override;
-        void resetActiveWidget() override;
+        void resetActiveWidget(Widget& widget) override;
 
     private:
         sf::RenderWindow m_window;
@@ -68,6 +68,8 @@ namespace ire::core::gui {
         void processSfmlMouseButtonPressedEvent(sf::Event& ev, TimePoint timestamp);
         void processSfmlMouseButtonReleasedEvent(sf::Event& ev, TimePoint timestamp);
         void processSfmlMouseMovedEvent(sf::Event& ev, TimePoint timestamp);
+
+        void reemitLastMouseMoved();
 
         template <typename EventT>
         void forwardEventWithPosition(EventT& ev)

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -4,6 +4,7 @@
 #include <SFML/Graphics.hpp>
 
 #include "Events.h"
+#include "EventRoot.h"
 
 #include "widgets/Panel.h"
 
@@ -11,13 +12,14 @@
 
 namespace ire::core::gui {
 
-    struct SystemWindow : EventEmitter
+    struct SystemWindow : EventEmitter, EventRoot
     {
 
         template <typename... Ts>
         SystemWindow(Ts&&... args) :
             m_window(std::forward<Ts>(args)...),
-            m_rootPanel(nullptr)
+            m_rootPanel(nullptr),
+            m_activeWidget(nullptr)
         {
         }
 
@@ -43,9 +45,16 @@ namespace ire::core::gui {
 
         void setRootPanel(Panel& panel);
 
+        void setActiveWidget(Widget& widget) override;
+        void resetActiveWidget() override;
+
     private:
         sf::RenderWindow m_window;
         Panel* m_rootPanel;
+
+        // The currently active widget receives all events regardless
+        // of the position of the mouse, etc.
+        Widget* m_activeWidget;
 
         void processSfmlEvent(sf::Event& ev);
 

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -5,6 +5,8 @@
 
 #include "Events.h"
 
+#include "widgets/Panel.h"
+
 #include <utility>
 
 namespace ire::core::gui {
@@ -14,9 +16,18 @@ namespace ire::core::gui {
 
         template <typename... Ts>
         SystemWindow(Ts&&... args) :
-            m_window(std::forward<Ts>(args)...)
+            m_window(std::forward<Ts>(args)...),
+            m_rootPanel(nullptr)
         {
         }
+
+        SystemWindow(const SystemWindow&) = delete;
+        SystemWindow(SystemWindow&&) = delete;
+
+        SystemWindow& operator=(const SystemWindow&) = delete;
+        SystemWindow& operator=(SystemWindow&&) = delete;
+
+        virtual ~SystemWindow() = default;
 
         [[nodiscard]] sf::RenderTarget& getRenderTarget();
 
@@ -28,8 +39,13 @@ namespace ire::core::gui {
 
         void display();
 
+        void draw();
+
+        void setRootPanel(Panel& panel);
+
     private:
         sf::RenderWindow m_window;
+        Panel* m_rootPanel;
 
         void processSfmlEvent(sf::Event& ev);
     };

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -19,7 +19,8 @@ namespace ire::core::gui {
         SystemWindow(Ts&&... args) :
             m_window(std::forward<Ts>(args)...),
             m_rootPanel(nullptr),
-            m_activeWidget(nullptr)
+            m_activeWidget(nullptr),
+            m_lastMousePosition(-1, -1)
         {
         }
 
@@ -56,11 +57,40 @@ namespace ire::core::gui {
         // of the position of the mouse, etc.
         Widget* m_activeWidget;
 
+        // To limit the number of MouseMoved events we only emit them if the position
+        // changed when rounded to the nearest integer.
+        sf::Vector2i m_lastMousePosition;
+
         void processSfmlEvent(sf::Event& ev, TimePoint timestamp);
 
         void processSfmlClosedEvent(sf::Event& ev, TimePoint timestamp);
 
         void processSfmlMouseButtonPressedEvent(sf::Event& ev, TimePoint timestamp);
+        void processSfmlMouseButtonReleasedEvent(sf::Event& ev, TimePoint timestamp);
+        void processSfmlMouseMovedEvent(sf::Event& ev, TimePoint timestamp);
+
+        template <typename EventT>
+        void forwardEventWithPosition(EventT& ev)
+        {
+            if (isOpen() && m_rootPanel != nullptr)
+            {
+                if (m_activeWidget != nullptr)
+                {
+                    m_activeWidget->onEvent(*this, ev);
+                    if (ev.handled)
+                    {
+                        return;
+                    }
+                }
+
+                if (m_rootPanel->clientBounds().contains(ev.position))
+                {
+                    m_rootPanel->onEvent(*this, ev);
+                }
+
+                emitEventIfNotHandled<EventT>(ev);
+            }
+        }
     };
 
 }

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -1,0 +1,39 @@
+#ifndef IRE_SYSTEM_WINDOW_H
+#define IRE_SYSTEM_WINDOW_H
+
+#include <SFML/Graphics.hpp>
+
+#include "Events.h"
+
+#include <utility>
+
+namespace ire::core::gui {
+
+    struct SystemWindow : EventEmitter
+    {
+
+        template <typename... Ts>
+        SystemWindow(Ts&&... args) :
+            m_window(std::forward<Ts>(args)...)
+        {
+        }
+
+        [[nodiscard]] sf::RenderTarget& getRenderTarget();
+
+        [[nodiscard]] bool isOpen() const;
+
+        void processEvents();
+
+        void close();
+
+        void display();
+
+    private:
+        sf::RenderWindow m_window;
+
+        void processSfmlEvent(sf::Event& ev);
+    };
+
+}
+
+#endif // !IRE_SYSTEM_WINDOW_H

--- a/src/core/gui/SystemWindow.h
+++ b/src/core/gui/SystemWindow.h
@@ -48,6 +48,10 @@ namespace ire::core::gui {
         Panel* m_rootPanel;
 
         void processSfmlEvent(sf::Event& ev);
+
+        void processSfmlClosedEvent(sf::Event& ev);
+
+        void processSfmlMouseButtonPressedEvent(sf::Event& ev);
     };
 
 }

--- a/src/core/gui/widgets/Button.cpp
+++ b/src/core/gui/widgets/Button.cpp
@@ -19,7 +19,23 @@ namespace ire::core::gui
 
 	void Button::draw(sf::RenderTarget& target)
 	{
-		target.draw(m_rectangleShape);
+		if (m_state == State::Armed)
+		{
+			auto shape = m_rectangleShape;
+			shape.move(sf::Vector2f(1.0f, 1.0f));
+			shape.setFillColor(shape.getFillColor() + sf::Color(40, 40, 40));
+			target.draw(shape);
+		}
+		else if (m_state == State::Hover)
+		{
+			auto shape = m_rectangleShape;
+			shape.setFillColor(shape.getFillColor() + sf::Color(40, 40, 40));
+			target.draw(shape);
+		}
+		else
+		{
+			target.draw(m_rectangleShape);
+		}
 	}
 	void Button::updateWidget()
 	{

--- a/src/core/gui/widgets/ClickableWidget.cpp
+++ b/src/core/gui/widgets/ClickableWidget.cpp
@@ -1,6 +1,8 @@
 #include "ClickableWidget.h"
 #include "WidgetType.h"
 
+#include <iostream>
+
 namespace ire::core::gui
 {
 	WidgetType const ClickableWidget::m_type = WidgetType::create<ClickableWidget>("ClickableWidget");
@@ -14,12 +16,19 @@ namespace ire::core::gui
 		Widget::setSize(size);
 		updateWidget();
 	}
+
 	void ClickableWidget::setPosition(const sf::Vector2f& position)
 	{
 		Widget::setPosition(position);
 		updateWidget();
 	}
+
 	void ClickableWidget::draw(sf::RenderTarget& target)
 	{
+	}
+
+	void ClickableWidget::onEvent(MouseButtonDownEvent& ev)
+	{
+		std::cout << "Mouse down detected. Initiate click for widget " << m_name << '\n';
 	}
 }

--- a/src/core/gui/widgets/ClickableWidget.cpp
+++ b/src/core/gui/widgets/ClickableWidget.cpp
@@ -27,7 +27,7 @@ namespace ire::core::gui
 	{
 	}
 
-	void ClickableWidget::onEvent(MouseButtonDownEvent& ev)
+	void ClickableWidget::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
 		std::cout << "Mouse down detected. Initiate click for widget " << m_name << '\n';
 	}

--- a/src/core/gui/widgets/ClickableWidget.cpp
+++ b/src/core/gui/widgets/ClickableWidget.cpp
@@ -29,6 +29,16 @@ namespace ire::core::gui
 
 	void ClickableWidget::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
-		std::cout << "Mouse down detected. Initiate click for widget " << m_name << '\n';
+		std::cout << "Mouse down detected. MouseButtonDownEvent on " << m_name << '\n';
+	}
+
+	void ClickableWidget::onEvent(EventRoot& sender, MouseButtonUpEvent& ev)
+	{
+		std::cout << "Mouse down detected. MouseButtonUpEvent on " << m_name << '\n';
+	}
+
+	void ClickableWidget::onEvent(EventRoot& sender, MouseMovedEvent& ev)
+	{
+		std::cout << "Mouse down detected. MouseMovedEvent on " << m_name << '\n';
 	}
 }

--- a/src/core/gui/widgets/ClickableWidget.cpp
+++ b/src/core/gui/widgets/ClickableWidget.cpp
@@ -29,16 +29,69 @@ namespace ire::core::gui
 
 	void ClickableWidget::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
-		std::cout << "Mouse down detected. MouseButtonDownEvent on " << m_name << '\n';
+		if (ev.button != sf::Mouse::Button::Left)
+		{
+			return;
+		}
+
+		m_state = State::Armed;
+
+		ev.handled = true;
 	}
 
 	void ClickableWidget::onEvent(EventRoot& sender, MouseButtonUpEvent& ev)
 	{
-		std::cout << "Mouse down detected. MouseButtonUpEvent on " << m_name << '\n';
+		if (ev.button != sf::Mouse::Button::Left)
+		{
+			return;
+		}
+
+		if (m_state == State::Armed && clientBounds().contains(ev.position))
+		{
+			onClick(ev);
+		}
+
+		m_state = State::Idle;
+		ev.handled = true;
+
+		sender.resetActiveWidget(*this);
 	}
 
 	void ClickableWidget::onEvent(EventRoot& sender, MouseMovedEvent& ev)
 	{
-		std::cout << "Mouse down detected. MouseMovedEvent on " << m_name << '\n';
+		if (clientBounds().contains(ev.position))
+		{
+			m_state = (
+				(m_state == State::Idle || m_state == State::Hover) 
+				? State::Hover 
+				: State::Armed);
+		}
+		else
+		{
+			m_state = 
+				(m_state == State::Armed || m_state == State::Disarmed)
+				? State::Disarmed
+				: State::Idle;
+		}
+
+		ev.handled = true;
+
+		if (m_state == State::Idle)
+		{
+			sender.resetActiveWidget(*this);
+		}
+		else
+		{
+			sender.setActiveWidget(*this);
+		}
+	}
+
+	void ClickableWidget::onClick(MouseButtonUpEvent& ev)
+	{
+		MouseClickEvent clickEv{};
+		clickEv.timestamp = ev.timestamp;
+		clickEv.button = ev.button;
+		clickEv.position = ev.position;
+		emitEvent<MouseClickEvent>(clickEv);
 	}
 }

--- a/src/core/gui/widgets/ClickableWidget.h
+++ b/src/core/gui/widgets/ClickableWidget.h
@@ -24,6 +24,8 @@ namespace ire::core::gui
         }
 
         void onEvent(EventRoot& sender, MouseButtonDownEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseButtonUpEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseMovedEvent& ev) override;
 
     private:
         

--- a/src/core/gui/widgets/ClickableWidget.h
+++ b/src/core/gui/widgets/ClickableWidget.h
@@ -23,7 +23,7 @@ namespace ire::core::gui
             return m_type;
         }
 
-        void onEvent(MouseButtonDownEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseButtonDownEvent& ev) override;
 
     private:
         

--- a/src/core/gui/widgets/ClickableWidget.h
+++ b/src/core/gui/widgets/ClickableWidget.h
@@ -27,8 +27,25 @@ namespace ire::core::gui
         void onEvent(EventRoot& sender, MouseButtonUpEvent& ev) override;
         void onEvent(EventRoot& sender, MouseMovedEvent& ev) override;
 
-    private:
-        
+    protected:
+
+        enum struct State
+        {
+            Idle,
+            Hover,
+            Armed,
+            Disarmed
+        };
+
+        State m_state = State::Idle;
+
+        void onClick(MouseButtonUpEvent& ev);
+    };
+
+    struct MouseClickEvent : TranslatedEvent
+    {
+        sf::Mouse::Button button;
+        sf::Vector2f position;
     };
 }
 

--- a/src/core/gui/widgets/ClickableWidget.h
+++ b/src/core/gui/widgets/ClickableWidget.h
@@ -23,6 +23,8 @@ namespace ire::core::gui
             return m_type;
         }
 
+        void onEvent(MouseButtonDownEvent& ev) override;
+
     private:
         
     };

--- a/src/core/gui/widgets/Container.cpp
+++ b/src/core/gui/widgets/Container.cpp
@@ -140,13 +140,13 @@ namespace ire::core::gui
 		return m_widgets.at(i).get();
 	}
 
-	void Container::onEvent(MouseButtonDownEvent& ev)
+	void Container::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
 		for (auto& widget : m_widgets)
 		{
 			if (widget->clientBounds().contains(ev.position))
 			{
-				widget->onEvent(ev);
+				widget->onEvent(sender, ev);
 
 				if (ev.handled)
 				{
@@ -155,6 +155,6 @@ namespace ire::core::gui
 			}
 		}
 
-		Widget::onEvent(ev);
+		Widget::onEvent(sender, ev);
 	}
 }

--- a/src/core/gui/widgets/Container.cpp
+++ b/src/core/gui/widgets/Container.cpp
@@ -139,4 +139,22 @@ namespace ire::core::gui
 	{
 		return m_widgets.at(i).get();
 	}
+
+	void Container::onEvent(MouseButtonDownEvent& ev)
+	{
+		for (auto& widget : m_widgets)
+		{
+			if (widget->clientBounds().contains(ev.position))
+			{
+				widget->onEvent(ev);
+
+				if (ev.handled)
+				{
+					break;
+				}
+			}
+		}
+
+		Widget::onEvent(ev);
+	}
 }

--- a/src/core/gui/widgets/Container.cpp
+++ b/src/core/gui/widgets/Container.cpp
@@ -142,19 +142,16 @@ namespace ire::core::gui
 
 	void Container::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
-		for (auto& widget : m_widgets)
-		{
-			if (widget->clientBounds().contains(ev.position))
-			{
-				widget->onEvent(sender, ev);
+		forwardEventWithPosition(sender, ev);
+	}
 
-				if (ev.handled)
-				{
-					break;
-				}
-			}
-		}
+	void Container::onEvent(EventRoot& sender, MouseButtonUpEvent& ev)
+	{
+		forwardEventWithPosition(sender, ev);
+	}
 
-		Widget::onEvent(sender, ev);
+	void Container::onEvent(EventRoot& sender, MouseMovedEvent& ev)
+	{
+		forwardEventWithPosition(sender, ev);
 	}
 }

--- a/src/core/gui/widgets/Container.h
+++ b/src/core/gui/widgets/Container.h
@@ -47,6 +47,8 @@ namespace ire::core::gui
         const WidgetType getType() const override;
 
         void onEvent(EventRoot& sender, MouseButtonDownEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseButtonUpEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseMovedEvent& ev) override;
 
     protected:
         std::vector<std::unique_ptr<Widget>> m_widgets;
@@ -57,6 +59,25 @@ namespace ire::core::gui
         const bool compareWithWidgetNameAt(std::size_t index, const std::string& name) const;
         Widget* getWidgetAt(int i);
         const Widget* getWidgetAt(int i) const;
+
+        template <typename EventT>
+        void forwardEventWithPosition(EventRoot& sender, EventT& ev)
+        {
+            for (auto& widget : m_widgets)
+            {
+                if (widget->clientBounds().contains(ev.position))
+                {
+                    widget->onEvent(sender, ev);
+
+                    if (ev.handled)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            Widget::onEvent(sender, ev);
+        }
     };
 }
 #endif // !CONTAINER_H

--- a/src/core/gui/widgets/Container.h
+++ b/src/core/gui/widgets/Container.h
@@ -46,6 +46,8 @@ namespace ire::core::gui
 
         const WidgetType getType() const override;
 
+        void onEvent(MouseButtonDownEvent& ev) override;
+
     protected:
         std::vector<std::unique_ptr<Widget>> m_widgets;
 

--- a/src/core/gui/widgets/Container.h
+++ b/src/core/gui/widgets/Container.h
@@ -46,7 +46,7 @@ namespace ire::core::gui
 
         const WidgetType getType() const override;
 
-        void onEvent(MouseButtonDownEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseButtonDownEvent& ev) override;
 
     protected:
         std::vector<std::unique_ptr<Widget>> m_widgets;

--- a/src/core/gui/widgets/Panel.cpp
+++ b/src/core/gui/widgets/Panel.cpp
@@ -81,10 +81,10 @@ namespace ire::core::gui
 		m_panelLayout->setLocalPosition({0, 0});
 	}
 
-	void Panel::onEvent(MouseButtonDownEvent& ev)
+	void Panel::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
-		m_panelLayout->onEvent(ev);
+		m_panelLayout->onEvent(sender, ev);
 
-		Widget::onEvent(ev);
+		Widget::onEvent(sender, ev);
 	}
 }

--- a/src/core/gui/widgets/Panel.cpp
+++ b/src/core/gui/widgets/Panel.cpp
@@ -83,8 +83,16 @@ namespace ire::core::gui
 
 	void Panel::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
-		m_panelLayout->onEvent(sender, ev);
+		forwardEvent(sender, ev);
+	}
 
-		Widget::onEvent(sender, ev);
+	void Panel::onEvent(EventRoot& sender, MouseButtonUpEvent& ev)
+	{
+		forwardEvent(sender, ev);
+	}
+
+	void Panel::onEvent(EventRoot& sender, MouseMovedEvent& ev)
+	{
+		forwardEvent(sender, ev);
 	}
 }

--- a/src/core/gui/widgets/Panel.cpp
+++ b/src/core/gui/widgets/Panel.cpp
@@ -80,4 +80,11 @@ namespace ire::core::gui
 		m_panelLayout->setOrigin(m_position);
 		m_panelLayout->setLocalPosition({0, 0});
 	}
+
+	void Panel::onEvent(MouseButtonDownEvent& ev)
+	{
+		m_panelLayout->onEvent(ev);
+
+		Widget::onEvent(ev);
+	}
 }

--- a/src/core/gui/widgets/Panel.h
+++ b/src/core/gui/widgets/Panel.h
@@ -39,12 +39,22 @@ namespace ire::core::gui
         }
 
         void onEvent(EventRoot& sender, MouseButtonDownEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseButtonUpEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseMovedEvent& ev) override;
 
     protected:
         std::unique_ptr<BoxLayout> m_panelLayout;
     private:
         void updateLayout();
         sf::RectangleShape m_rectangleShape;
+
+        template <typename EventT>
+        void forwardEvent(EventRoot& sender, EventT& ev)
+        {
+            m_panelLayout->onEvent(sender, ev);
+
+            Widget::onEvent(sender, ev);
+        }
     };
 }
 

--- a/src/core/gui/widgets/Panel.h
+++ b/src/core/gui/widgets/Panel.h
@@ -38,7 +38,7 @@ namespace ire::core::gui
             return m_type;
         }
 
-        void onEvent(MouseButtonDownEvent& ev) override;
+        void onEvent(EventRoot& sender, MouseButtonDownEvent& ev) override;
 
     protected:
         std::unique_ptr<BoxLayout> m_panelLayout;

--- a/src/core/gui/widgets/Panel.h
+++ b/src/core/gui/widgets/Panel.h
@@ -38,6 +38,8 @@ namespace ire::core::gui
             return m_type;
         }
 
+        void onEvent(MouseButtonDownEvent& ev) override;
+
     protected:
         std::unique_ptr<BoxLayout> m_panelLayout;
     private:

--- a/src/core/gui/widgets/Widget.cpp
+++ b/src/core/gui/widgets/Widget.cpp
@@ -85,7 +85,7 @@ namespace ire::core::gui
 		return sf::FloatRect(m_position, m_size);
 	}
 
-	void Widget::onEvent(MouseButtonDownEvent& ev)
+	void Widget::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
 	{
 		emitEventIfNotHandled<MouseButtonDownEvent>(ev);
 	}

--- a/src/core/gui/widgets/Widget.cpp
+++ b/src/core/gui/widgets/Widget.cpp
@@ -87,9 +87,6 @@ namespace ire::core::gui
 
 	void Widget::onEvent(MouseButtonDownEvent& ev)
 	{
-		if (!ev.handled)
-		{
-			emitEvent<MouseButtonDownEvent>(ev);
-		}
+		emitEventIfNotHandled<MouseButtonDownEvent>(ev);
 	}
 }

--- a/src/core/gui/widgets/Widget.cpp
+++ b/src/core/gui/widgets/Widget.cpp
@@ -84,9 +84,4 @@ namespace ire::core::gui
 	{
 		return sf::FloatRect(m_position, m_size);
 	}
-
-	void Widget::onEvent(EventRoot& sender, MouseButtonDownEvent& ev)
-	{
-		emitEventIfNotHandled<MouseButtonDownEvent>(ev);
-	}
 }

--- a/src/core/gui/widgets/Widget.cpp
+++ b/src/core/gui/widgets/Widget.cpp
@@ -79,4 +79,17 @@ namespace ire::core::gui
 		return m_parent;
 
 	}
+
+	[[nodiscard]] sf::FloatRect Widget::clientBounds() const 
+	{
+		return sf::FloatRect(m_position, m_size);
+	}
+
+	void Widget::onEvent(MouseButtonDownEvent& ev)
+	{
+		if (!ev.handled)
+		{
+			emitEvent<MouseButtonDownEvent>(ev);
+		}
+	}
 }

--- a/src/core/gui/widgets/Widget.h
+++ b/src/core/gui/widgets/Widget.h
@@ -44,6 +44,10 @@ namespace ire::core::gui
         
         virtual const WidgetType getType() const = 0;
 
+        [[nodiscard]] sf::FloatRect clientBounds() const;
+
+        virtual void onEvent(MouseButtonDownEvent& ev);
+
     protected:
         std::string m_name;
 

--- a/src/core/gui/widgets/Widget.h
+++ b/src/core/gui/widgets/Widget.h
@@ -4,6 +4,7 @@
 #include "WidgetType.h"
 
 #include "core/gui/Events.h"
+#include "core/gui/EventRoot.h"
 
 #include <SFML/Graphics.hpp>
 
@@ -46,7 +47,7 @@ namespace ire::core::gui
 
         [[nodiscard]] sf::FloatRect clientBounds() const;
 
-        virtual void onEvent(MouseButtonDownEvent& ev);
+        virtual void onEvent(EventRoot& sender, MouseButtonDownEvent& ev);
 
     protected:
         std::string m_name;

--- a/src/core/gui/widgets/Widget.h
+++ b/src/core/gui/widgets/Widget.h
@@ -5,6 +5,7 @@
 
 #include "core/gui/Events.h"
 #include "core/gui/EventRoot.h"
+#include "core/gui/RawEventHandler.h"
 
 #include <SFML/Graphics.hpp>
 
@@ -14,7 +15,7 @@ namespace ire::core::gui
 {
     struct Container;
     // Base class for all Widgets and Layouts
-    struct Widget : EventEmitter
+    struct Widget : RawEventHandler
     {
         Widget() = default;
         virtual ~Widget();
@@ -46,8 +47,6 @@ namespace ire::core::gui
         virtual const WidgetType getType() const = 0;
 
         [[nodiscard]] sf::FloatRect clientBounds() const;
-
-        virtual void onEvent(EventRoot& sender, MouseButtonDownEvent& ev);
 
     protected:
         std::string m_name;

--- a/tests/core/gui/EventsTests.cpp
+++ b/tests/core/gui/EventsTests.cpp
@@ -8,23 +8,19 @@
 
 using namespace ire::core::gui;
 
-namespace {
+struct MockedWidget : EventEmitter
+{
+    virtual void emitMouseDownEvent() = 0;
+};
 
-    struct MockedWidget : EventEmitter
+struct MockedButton : MockedWidget
+{
+    void emitMouseDownEvent() override
     {
-        virtual void emitMouseDownEvent() = 0;
-    };
-
-    struct MockedButton : MockedWidget
-    {
-        void emitMouseDownEvent() override
-        {
-            auto ev = MouseDownEvent{ {}, sf::Mouse::Button::Left, sf::Vector2f(123, 321) };
-            emitEvent(ev);
-        }
-    };
-
-}
+        auto ev = MouseDownEvent{ {}, sf::Mouse::Button::Left, sf::Vector2f(123, 321) };
+        emitEvent(ev);
+    }
+};
 
 TEST_CASE("Event emitter tests", "[events]")
 {
@@ -81,7 +77,7 @@ TEST_CASE("Event emitter tests", "[events]")
     {
         counter = 0;
         std::unique_ptr<MockedWidget> widget = std::make_unique<MockedButton>();
-        
+
         (void)widget->addTemporaryEventListener<MouseDownEvent>(rightListener);
         widget->emitMouseDownEvent();
         REQUIRE(counter == 0);


### PR DESCRIPTION
Event processing is being added. Currently the window can process sfml events and `MouseButtonDownEvent` is propagated down the widget tree. I added a diagnostic message for testing when a mouse button is pushed down while pointing a clickable widget.

Currently the following changes were made:
- Created SystemWindow that encapsulates sf::RenderWindow and takes some responsibilities away from the engine
- The specific window setup is moved from engine to client
- Added `clientBounds` method to `Widget` that returns the bounds of the widget in window (client) coordinates. This is used to check when an event should be dispatched to a given control.
- The window can handle and propagate `WindowClosedEvent`.
- The window can handle and propagate `MouseButtonDownEvent`

This is only the beginning, but I would like to get some affirmation on the current state of things.