### PR TITLE
Tile overlays.

### DIFF
--- a/src/client/gui/widgets/WorldView.cpp
+++ b/src/client/gui/widgets/WorldView.cpp
@@ -52,6 +52,10 @@ namespace ire::client::gui
                 overlay.border->visible = { true, true, true, true };
                 mainSurface.setTileOverlays({ overlay });
             }
+            else
+            {
+                mainSurface.resetTileOverlays();
+            }
         }
         //
 

--- a/src/client/gui/widgets/WorldView.h
+++ b/src/client/gui/widgets/WorldView.h
@@ -6,6 +6,7 @@
 #include "core/world/World.h"
 
 #include <memory>
+#include <optional>
 
 namespace ire::client::gui
 {
@@ -34,13 +35,15 @@ namespace ire::client::gui
         // Why the hell is this virtual?
         void updateWidget() override;
 
-        void onEvent(core::gui::EventRoot& sender, core::gui::MouseButtonDownEvent& ev);
+        void onEvent(core::gui::EventRoot& sender, core::gui::MouseButtonDownEvent& ev) override;
+        void onEvent(core::gui::EventRoot& sender, core::gui::MouseMovedEvent& ev) override;
 
         void onStoppedBeingActive() override;
 
     private:
         ire::core::world::World* m_world;
         State m_state;
+        std::optional<sf::Vector2f> m_mousePos;
 
         void updateCamera();
     };

--- a/src/core/util/FourWay.h
+++ b/src/core/util/FourWay.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace ire::core::util
+{
+
+    template <typename T>
+    struct FourWay
+    {
+        T top;
+        T right;
+        T bottom;
+        T left;
+    };
+
+}

--- a/src/core/world/tiled_top_down/TileOverlay.h
+++ b/src/core/world/tiled_top_down/TileOverlay.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <vector>
+#include <optional>
+
+#include <SFML/System/Vector2.hpp>
+#include <SFML/Graphics/Color.hpp>
+
+#include "core/util/FourWay.h"
+
+#include "core/gfx/TextureAtlas.h"
+
+namespace ire::core::world
+{
+
+    struct TileOverlayBorder
+    {
+        util::FourWay<bool> visible;
+        sf::Color color;
+        float thickness;
+    };
+
+    struct TileOverlaySprite
+    {
+        gfx::TextureView sprite;
+        sf::Vector2f size;
+    };
+
+    struct TileOverlay
+    {
+        sf::Vector2i position;
+        std::optional<TileOverlayBorder> border;
+        std::optional<TileOverlaySprite> sprite;
+    };
+
+}

--- a/src/core/world/tiled_top_down/TiledTopDownSurface.cpp
+++ b/src/core/world/tiled_top_down/TiledTopDownSurface.cpp
@@ -72,6 +72,21 @@ namespace ire::core::world
         m_cameraCenter += diff;
     }
 
+    void TiledTopDownSurface::setTileOverlays(std::vector<TileOverlay>&& overlays)
+    {
+        m_tileOverlays = std::move(overlays);
+    }
+
+    void TiledTopDownSurface::resetTileOverlays()
+    {
+        m_tileOverlays.clear();
+    }
+
+    [[nodiscard]] std::vector<TileOverlay> TiledTopDownSurface::getSpriteOverlays() const
+    {
+        return m_tileOverlays;
+    }
+
     [[nodiscard]] float TiledTopDownSurface::getZoom() const
     {
         return m_zoom;
@@ -86,6 +101,7 @@ namespace ire::core::world
         target.setView(surfaceView);
 
         drawGround(target, states);
+        drawTileOverlays(target, states);
 
         target.setView(oldView);
     }
@@ -211,6 +227,152 @@ namespace ire::core::world
                 }
             }
         }
+    }
+
+    void TiledTopDownSurface::drawTileOverlays(sf::RenderTarget& target, sf::RenderStates& states)
+    {
+        for (auto& overlay : m_tileOverlays)
+        {
+            drawTileOverlay(target, states, overlay);
+        }
+    }
+
+    void TiledTopDownSurface::drawTileOverlay(sf::RenderTarget& target, sf::RenderStates& states, const TileOverlay& overlay)
+    {
+        if (overlay.border.has_value())
+        {
+            drawTileOverlayBorder(target, states, *(overlay.border), overlay.position);
+        }
+
+        if (overlay.sprite.has_value())
+        {
+            drawTileOverlaySprite(target, states, *(overlay.sprite), overlay.position);
+        }
+    }
+
+    void TiledTopDownSurface::drawTileOverlayBorder(sf::RenderTarget& target, sf::RenderStates& states, const TileOverlayBorder& overlay, const sf::Vector2i& position)
+    {
+        sf::VertexArray va(sf::Triangles);
+        
+        const auto x = position.x;
+        const auto y = position.y;
+
+        const auto topLeftElevation = m_gridPoints(x, y).getElevation();
+        const auto topRightElevation = m_gridPoints(x + 1, y).getElevation();
+        const auto bottomRightElevation = m_gridPoints(x + 1, y + 1).getElevation();
+        const auto bottomLeftElevation = m_gridPoints(x, y + 1).getElevation();
+        const auto midElevation =
+            (topLeftElevation
+            + topRightElevation
+            + bottomRightElevation
+            + bottomLeftElevation) * 0.25f;
+
+        const auto topLeft = sf::Vector2f(x, y - topLeftElevation * elevationSqueeze);
+        const auto topRight = sf::Vector2f(x + 1, y - topRightElevation * elevationSqueeze);
+        const auto bottomRight = sf::Vector2f(x + 1, y + 1 - bottomRightElevation * elevationSqueeze);
+        const auto bottomLeft = sf::Vector2f(x, y + 1 - bottomLeftElevation * elevationSqueeze);
+        const auto mid = sf::Vector2f(x + 0.5f, y + 0.5f - midElevation * elevationSqueeze);
+
+        const auto color = overlay.color;
+        const auto thickness = overlay.thickness;
+        const auto halfThickness = thickness * 0.5f;
+
+        const auto outwardTopLeft = (topLeft - mid) * halfThickness;
+        const auto outwardTopRight = (topRight - mid) * halfThickness;
+        const auto outwardBottomRight = (bottomRight - mid) * halfThickness;
+        const auto outwardBottomLeft = (bottomLeft - mid) * halfThickness;
+
+        const auto vTopLeftOuter = sf::Vertex(topLeft + outwardTopLeft, color);
+        const auto vTopLeftInner = sf::Vertex(topLeft - outwardTopLeft, color);
+        const auto vTopRightOuter = sf::Vertex(topRight + outwardTopRight, color);
+        const auto vTopRightInner = sf::Vertex(topRight - outwardTopRight, color);
+        const auto vBottomRightOuter = sf::Vertex(bottomRight + outwardBottomRight, color);
+        const auto vBottomRightInner = sf::Vertex(bottomRight - outwardBottomRight, color);
+        const auto vBottomLeftOuter = sf::Vertex(bottomLeft + outwardBottomLeft, color);
+        const auto vBottomLeftInner = sf::Vertex(bottomLeft - outwardBottomLeft, color);
+
+        if (overlay.visible.top)
+        {
+            va.append(vTopLeftOuter);
+            va.append(vTopLeftInner);
+            va.append(vTopRightOuter);
+
+            va.append(vTopLeftInner);
+            va.append(vTopRightOuter);
+            va.append(vTopRightInner);
+        }
+
+        if (overlay.visible.right && bottomRight.y > topRight.y)
+        {
+            va.append(vTopRightOuter);
+            va.append(vTopRightInner);
+            va.append(vBottomRightOuter);
+
+            va.append(vTopRightInner);
+            va.append(vBottomRightOuter);
+            va.append(vBottomRightInner);
+        }
+
+        if (overlay.visible.bottom)
+        {
+            va.append(vBottomRightOuter);
+            va.append(vBottomRightInner);
+            va.append(vBottomLeftOuter);
+
+            va.append(vBottomRightInner);
+            va.append(vBottomLeftOuter);
+            va.append(vBottomLeftInner);
+        }
+
+        if (overlay.visible.left && bottomLeft.y > topLeft.y)
+        {
+            va.append(vBottomLeftOuter);
+            va.append(vBottomLeftInner);
+            va.append(vTopLeftOuter);
+
+            va.append(vBottomLeftInner);
+            va.append(vTopLeftOuter);
+            va.append(vTopLeftInner);
+        }
+
+        target.draw(va);
+    }
+
+    void TiledTopDownSurface::drawTileOverlaySprite(sf::RenderTarget& target, sf::RenderStates& states, const TileOverlaySprite& overlay, const sf::Vector2i& position)
+    {
+        const auto x = position.x;
+        const auto y = position.y;
+
+        const auto topLeftElevation = m_gridPoints(x, y).getElevation();
+        const auto topRightElevation = m_gridPoints(x + 1, y).getElevation();
+        const auto bottomRightElevation = m_gridPoints(x + 1, y + 1).getElevation();
+        const auto bottomLeftElevation = m_gridPoints(x, y + 1).getElevation();
+        const auto midElevation =
+            (topLeftElevation
+            + topRightElevation
+            + bottomRightElevation
+            + bottomLeftElevation) * 0.25f;
+
+        const auto mid = sf::Vector2f(x + 0.5f, y + 0.5f - midElevation * elevationSqueeze);
+
+        const auto halfSize = sf::Vector2f(overlay.size.x * 0.5f, overlay.size.y * 0.5f * verticalSqueeze);
+
+        const auto& texBounds = overlay.sprite.getBounds();
+        const auto& texture = overlay.sprite.getTexture();
+
+        const auto topLeftTex = sf::Vector2f(texBounds.left, texBounds.top);
+        const auto topRightTex = sf::Vector2f(texBounds.left + texBounds.width, texBounds.top);
+        const auto bottomRightTex = sf::Vector2f(texBounds.left + texBounds.width, texBounds.top + texBounds.height);
+        const auto bottomLeftTex = sf::Vector2f(texBounds.left, texBounds.top + texBounds.height);
+
+        sf::RectangleShape sprite;
+        sprite.setPosition(mid - halfSize);
+        sprite.setSize(halfSize * 2.0f);
+        sprite.setFillColor(sf::Color::Cyan);
+        sprite.setTexture(&texture);
+        sprite.setTextureRect(sf::IntRect(texBounds));
+
+        target.draw(sprite);
     }
 
     [[nodiscard]] sf::Vector3f TiledTopDownSurface::getGridPointNormal(int x, int y) const

--- a/src/core/world/tiled_top_down/TiledTopDownSurface.cpp
+++ b/src/core/world/tiled_top_down/TiledTopDownSurface.cpp
@@ -82,6 +82,29 @@ namespace ire::core::world
         m_tileOverlays.clear();
     }
 
+    [[nodiscard]] sf::Vector2f TiledTopDownSurface::mapClientToWorldPosition(sf::RenderTarget& target, sf::Vector2f clientPos) const
+    {
+        // TODO: do this more efficiently
+        // TODO: do a proper raycast
+        auto cameraView = getCameraView(target);
+        return target.mapPixelToCoords(sf::Vector2i(clientPos), cameraView);
+    }
+
+    [[nodiscard]] std::optional<sf::Vector2i> TiledTopDownSurface::mapClientToTilePosition(sf::RenderTarget& target, sf::Vector2f clientPos) const
+    {
+        auto worldPos = sf::Vector2i(mapClientToWorldPosition(target, clientPos));
+        if (
+            worldPos.x < 0
+            || worldPos.y < 0
+            || worldPos.x >= m_width
+            || worldPos.y >= m_height)
+        {
+            return std::nullopt;
+        }
+
+        return worldPos;
+    }
+
     [[nodiscard]] std::vector<TileOverlay> TiledTopDownSurface::getSpriteOverlays() const
     {
         return m_tileOverlays;

--- a/src/core/world/tiled_top_down/TiledTopDownSurface.h
+++ b/src/core/world/tiled_top_down/TiledTopDownSurface.h
@@ -18,6 +18,7 @@
 #include <SFML/Graphics/VertexBuffer.hpp>
 
 #include <cmath>
+#include <optional>
 
 namespace ire::core::world
 {
@@ -40,6 +41,9 @@ namespace ire::core::world
         void setTileOverlays(std::vector<TileOverlay>&& overlays);
         void resetTileOverlays();
         [[nodiscard]] std::vector<TileOverlay> getSpriteOverlays() const;
+
+        [[nodiscard]] sf::Vector2f mapClientToWorldPosition(sf::RenderTarget& target, sf::Vector2f clientPos) const;
+        [[nodiscard]] std::optional<sf::Vector2i> mapClientToTilePosition(sf::RenderTarget& target, sf::Vector2f clientPos) const;
 
         [[nodiscard]] float getZoom() const;
 

--- a/src/core/world/tiled_top_down/TiledTopDownSurface.h
+++ b/src/core/world/tiled_top_down/TiledTopDownSurface.h
@@ -3,6 +3,8 @@
 #include "TopDownGroundTile.h"
 #include "TopDownGridPoint.h"
 
+#include "TileOverlay.h"
+
 #include "core/resource/Resource.h"
 
 #include "core/gfx/TextureAtlas.h"
@@ -34,6 +36,10 @@ namespace ire::core::world
 
         void changeZoom(float multiplier);
         void moveCamera(sf::Vector2f diff);
+
+        void setTileOverlays(std::vector<TileOverlay>&& overlays);
+        void resetTileOverlays();
+        [[nodiscard]] std::vector<TileOverlay> getSpriteOverlays() const;
 
         [[nodiscard]] float getZoom() const;
 
@@ -85,10 +91,17 @@ namespace ire::core::world
 
         util::Array2<GroundChunkCache> m_groundChunkCache;
 
+        std::vector<TileOverlay> m_tileOverlays;
+
         void appendGroundTileGeometry(std::vector<sf::Vertex>& va, int x, int y);
         void generateRandomWorld();
 
         void drawGround(sf::RenderTarget& target, sf::RenderStates& states);
+
+        void drawTileOverlays(sf::RenderTarget& target, sf::RenderStates& states);
+        void drawTileOverlay(sf::RenderTarget& target, sf::RenderStates& states, const TileOverlay& overlay);
+        void drawTileOverlayBorder(sf::RenderTarget& target, sf::RenderStates& states, const TileOverlayBorder& overlay, const sf::Vector2i& position);
+        void drawTileOverlaySprite(sf::RenderTarget& target, sf::RenderStates& states, const TileOverlaySprite& overlay, const sf::Vector2i& position);
 
         GroundChunkCache& updateChunkCacheIfRequired(int cx, int cy);
     };


### PR DESCRIPTION
This PR adds tile overlays.
![obraz](https://user-images.githubusercontent.com/8037982/103566304-15b90100-4ec2-11eb-9347-327f1639595a.png)

The overlay can span multiple tiles (and can be sparse). The overlay is stored by the surface and only one overlay can be active for now. The overlay on the screenshot is managed by WorldView class for now; during rendering. It does a simple transform from screen space to world space to determine the tile coordinates so elevation is not taken into account (TODO: raycast surface).

The overlay is a vector of single tile overlays. A single tile overlay may consist of one or more of the following:
- border
  - can be enabled for each side separately
  - thickness in world space coordinates (1.0f == one tile)
  - color
- sprite
  - TextureView
  - size in world space coordinates

The border rendering respects perspective and elevation. The sprite rendering respects perspective (it's renderred squashed vertically) but the elevation used is the elevation for the middle of the tile.